### PR TITLE
Rename user options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Expand to see the list of all the default options below.
 ```lua
 {
   -- Events that set the default input method.
-  set_default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+  default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
 
   -- Events that save the current input method.
-  save_im_events = { "InsertLeavePre" },
+  save_im_state_events = { "InsertLeavePre" },
   
   -- Events that restore the previously saved input method.
-  set_previous_im_events = { "InsertEnter" },
+  restore_im_events = { "InsertEnter" },
 
   -- Windows settings
   windows = {
@@ -87,11 +87,11 @@ Expand to see the list of all the default options below.
   };
   
   -- macOS settings
-  mac = {
+  macos = {
     -- Enable or disable the plugin on macOS.
     enabled = false,
 
-    -- The input method set when `set_default_im_events` is triggered.
+    -- The input method set when `default_im_events` is triggered.
     default_im = "",
   },
   
@@ -100,13 +100,13 @@ Expand to see the list of all the default options below.
     -- Enable or disable the plugin on Linux.
     enabled = false,
 
-    -- The input method set when `set_default_im_events` is triggered.
+    -- The input method set when `default_im_events` is triggered.
     default_im = "",
 
-    -- The command used to get the current input method when `save_im_events` is triggered.
-    obtain_im_command = {},
+    -- The command used to get the current input method when `save_im_state_events` is triggered.
+    get_im_command = {},
 
-    -- The command used to set the input method when `set_default_im_events` or `set_previous_im_events` is triggered.
+    -- The command used to set the input method when `default_im_events` or `restore_im_events` is triggered.
     set_im_command = {},
   },
 }
@@ -119,29 +119,29 @@ Expand to see the list of all the default options below.
 
 ### 🔧 General Configuration
 
-#### `set_default_im_events`
+#### `default_im_events`
 
 Events that **set the default input method**.
 
 ```lua
-set_default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" }
+default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" }
 ```
 
-#### `save_im_events`
+#### `save_im_state_events`
 
 Events that **save the current input method**.<br />
-The saved input method is restored when `set_previous_im_events` is triggered.
+The saved input method is restored when `restore_im_events` is triggered.
 
 ```lua
-save_im_events = { "InsertLeavePre" },
+save_im_state_events = { "InsertLeavePre" },
 ```
 
-#### `set_previous_im_events`
+#### `restore_im_events`
 
 Events that **restore the previously saved input method**.
 
 ```lua
-set_previous_im_events = { "InsertEnter" },
+restore_im_events = { "InsertEnter" },
 ```
 
 > [!TIP]
@@ -150,9 +150,9 @@ set_previous_im_events = { "InsertEnter" },
 > To set the default input method when switching modes:
 >
 > ```lua
-> set_default_im_events = { "VimEnter", "InsertEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-> save_im_events = {},
-> set_previous_im_events = {},
+> default_im_events = { "VimEnter", "InsertEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+> save_im_state_events = {},
+> restore_im_events = {},
 > ```
 
 ### 🪟 Windows Configuration
@@ -169,22 +169,22 @@ windows = {
 
 ### 🍎 macOS Configuration
 
-#### `mac.enabled`
+#### `macos.enabled`
 
 Enable or disable the plugin on macOS.
 
 ```lua
-mac = {
+macos = {
   enabled = true,
 },
 ```
 
-#### `mac.default_im`
+#### `macos.default_im`
 
-The input method set when `set_default_im_events` is triggered.
+The input method set when `default_im_events` is triggered.
 
 ```lua
-mac = {
+macos = {
   default_im = "com.apple.keylayout.ABC",
 },
 ```
@@ -203,7 +203,7 @@ linux = {
 
 #### `linux.default_im`
 
-The input method set when `set_default_im_events` is triggered.
+The input method set when `default_im_events` is triggered.
 
 ```lua
 linux = {
@@ -211,19 +211,19 @@ linux = {
 },
 ```
 
-#### `linux.obtain_im_command`
+#### `linux.get_im_command`
 
-The command used to **get the current input method** when `save_im_events` is triggered.
+The command used to **get the current input method** when `save_im_state_events` is triggered.
 
 ```lua
 linux = {
-  obtain_im_command = { "fcitx5-remote", "-n" },
+  get_im_command = { "fcitx5-remote", "-n" },
 },
 ```
 
 #### `linux.set_im_command`
 
-The command used to **set the input method** when `set_default_im_events` or `set_previous_im_events` is triggered.
+The command used to **set the input method** when `default_im_events` or `restore_im_events` is triggered.
 
 ```lua
 linux = {

--- a/lua/im-switch/health.lua
+++ b/lua/im-switch/health.lua
@@ -26,7 +26,7 @@ local function check_os_options()
 
   if platform_opts.enabled then
     vim.health.ok("Plugin is enabled")
-    if os == "mac" or os == "linux" then
+    if os == "macos" or os == "linux" then
       if type(platform_opts.default_im) == "string" then
         vim.health.ok("default_im is " .. platform_opts.default_im)
       else
@@ -34,7 +34,7 @@ local function check_os_options()
       end
     end
     if os == "linux" then
-      for _, key in ipairs({ "obtain_im_command", "set_im_command" }) do
+      for _, key in ipairs({ "get_im_command", "set_im_command" }) do
         if type(platform_opts[key]) == "table" then
           vim.health.ok(key .. " is " .. '"' .. utils.concat(platform_opts[key]) .. '"')
         elseif type(platform_opts[key]) == "string" then
@@ -97,7 +97,7 @@ local function check_binary()
     end
   elseif os == "linux" then
     local commands = {} -- set to store unique command names
-    for _, key in ipairs({ "obtain_im_command", "set_im_command" }) do
+    for _, key in ipairs({ "get_im_command", "set_im_command" }) do
       local command = get_command(opts.linux[key])
       if not command then
         vim.health.error("Invalid command format of " .. key)
@@ -112,7 +112,7 @@ local function check_binary()
     end
   else
     local arch = jit.arch
-    if ((os == "windows" or os == "wsl") and arch == "x64") or (os == "mac" and arch == "arm64") then
+    if ((os == "windows" or os == "wsl") and arch == "x64") or (os == "macos" and arch == "arm64") then
       vim.health.ok("Prebuilt binary is used: " .. utils.get_prebuilt_executable_path())
     else
       vim.health.error("Prebuilt binary is not supported on this OS/architecture")

--- a/lua/im-switch/im.lua
+++ b/lua/im-switch/im.lua
@@ -11,10 +11,10 @@ local function get_current_im(opts)
   local os = utils.detect_os()
   local command
 
-  if os == "wsl" or os == "windows" or os == "mac" then
+  if os == "wsl" or os == "windows" or os == "macos" then
     command = { utils.get_executable_path(), "--get" }
   elseif os == "linux" then
-    command = utils.split(opts.linux.obtain_im_command)
+    command = utils.split(opts.linux.get_im_command)
   else
     error("Unsupported OS: " .. os)
   end
@@ -50,8 +50,8 @@ function M.ime_off(opts)
 
   if (os == "wsl") or (os == "windows") then
     result = vim.system({ utils.get_executable_path(), "--disable" }):wait()
-  elseif os == "mac" then
-    result = vim.system({ utils.get_executable_path(), "--set", opts.mac.default_im }):wait()
+  elseif os == "macos" then
+    result = vim.system({ utils.get_executable_path(), "--set", opts.macos.default_im }):wait()
   elseif os == "linux" then
     local command = utils.split(opts.linux.set_im_command)
     table.insert(command, opts.linux.default_im)
@@ -85,7 +85,7 @@ function M.restore_previous_im(opts)
     elseif previous_im == "off" then
       result = vim.system({ utils.get_executable_path(), "--disable" }):wait()
     end
-  elseif os == "mac" then
+  elseif os == "macos" then
     result = vim.system({ utils.get_executable_path(), "--set", previous_im }):wait()
   elseif os == "linux" then
     local command = utils.split(opts.linux.set_im_command)

--- a/lua/im-switch/init.lua
+++ b/lua/im-switch/init.lua
@@ -1,100 +1,15 @@
 local im = require("im-switch.im")
-local utils = require("im-switch.utils")
-
----@class WindowsSettings
----@field enabled boolean
-
----@class MacSettings
----@field enabled boolean
----@field default_im? string
-
----@class LinuxSettings
----@field enabled boolean
----@field default_im? string
----@field obtain_im_command? string|string[]
----@field set_im_command? string|string[]
-
----@class PluginOptions
----@field set_default_im_events string[]
----@field save_im_events string[]
----@field set_previous_im_events string[]
----@field windows? WindowsSettings
----@field mac? MacSettings
----@field linux? LinuxSettings
-
---==============================================================
--- Local Functions
---==============================================================
-
---- Default plugin options
----@type PluginOptions
-local default_opts = {
-  set_default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-  set_previous_im_events = { "InsertEnter" },
-  save_im_events = { "InsertLeavePre" },
-  windows = {
-    enabled = false,
-  },
-  mac = {
-    enabled = false,
-  },
-  linux = {
-    enabled = false,
-  },
-}
-
---- Initialize plugin options
----@param opts PluginOptions
----@return PluginOptions
-local function initialize_opts(opts)
-  -- Extend the opts with default_opts, overwriting nil values in opts with default_opts
-  return vim.tbl_extend("force", default_opts, opts)
-end
-
---- Check if the plugin is enabled and all required settings are properly configured
----@param opts PluginOptions
----@return boolean
-local function is_plugin_configured(opts)
-  local os = utils.detect_os()
-
-  if os == "wsl" or os == "windows" then
-    return opts.windows.enabled
-  elseif os == "mac" then
-    if opts.mac.enabled and not opts.mac.default_im then
-      error("The 'mac.default_im' field must be defined when mac plugin is enabled")
-      return false
-    end
-    return opts.mac.enabled
-  elseif os == "linux" then
-    if opts.linux.enabled then
-      local required_fields = { "default_im", "obtain_im_command", "set_im_command" }
-      for _, field in ipairs(required_fields) do
-        if not opts.linux[field] then
-          error(string.format("The 'linux.%s' field must be defined when linux plugin is enabled", field))
-          return false
-        end
-      end
-      return true
-    end
-    return false
-  else
-    error("Unsupported OS")
-  end
-end
-
---==============================================================
--- Public Functions
---==============================================================
+local options = require("im-switch.options")
 
 local M = {}
 
 ---@param opts PluginOptions User options
 function M.setup(opts)
   -- Initialize options
-  M.opts = initialize_opts(opts)
+  M.opts = options.initialize_opts(opts)
 
   -- If the plugin is not enabled for the current OS, exit early
-  if not is_plugin_configured(M.opts) then
+  if not options.is_plugin_configured(M.opts) then
     return
   end
 

--- a/lua/im-switch/init.lua
+++ b/lua/im-switch/init.lua
@@ -16,9 +16,9 @@ function M.setup(opts)
   -- Create an autocommand group to manage the events
   local group_id = vim.api.nvim_create_augroup("im-switch", { clear = true })
 
-  -- Set up autocommand to disable IM when events in `set_default_im_events` are triggered
-  if #M.opts.set_default_im_events > 0 then
-    vim.api.nvim_create_autocmd(M.opts.set_default_im_events, {
+  -- Set up autocommand to set the default input method when `default_im_events` is triggered
+  if #M.opts.default_im_events > 0 then
+    vim.api.nvim_create_autocmd(M.opts.default_im_events, {
       callback = function()
         im.ime_off(M.opts)
       end,
@@ -26,9 +26,9 @@ function M.setup(opts)
     })
   end
 
-  -- Set up autocommand to restore previous IM when events in `set_previous_im_events` are triggered
-  if #M.opts.set_previous_im_events > 0 then
-    vim.api.nvim_create_autocmd(M.opts.set_previous_im_events, {
+  -- Set up autocommand to restore the previous input method when `restore_im_events` is triggered
+  if #M.opts.restore_im_events > 0 then
+    vim.api.nvim_create_autocmd(M.opts.restore_im_events, {
       callback = function()
         im.restore_previous_im(M.opts)
       end,
@@ -36,9 +36,9 @@ function M.setup(opts)
     })
   end
 
-  -- Set up autocommand to save the current IM when events in `save_im_events` are triggered
-  if #M.opts.save_im_events > 0 then
-    vim.api.nvim_create_autocmd(M.opts.save_im_events, {
+  -- Set up autocommand to save the current input method when `save_im_state_events` is triggered
+  if #M.opts.save_im_state_events > 0 then
+    vim.api.nvim_create_autocmd(M.opts.save_im_state_events, {
       callback = function()
         im.save_im(M.opts)
       end,

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -1,0 +1,86 @@
+local utils = require("im-switch.utils")
+
+--- Windows settings
+---@class WindowsSettings
+---@field enabled boolean
+
+--- macOS settings
+---@class MacSettings
+---@field enabled boolean
+---@field default_im? string
+
+--- Linux settings
+---@class LinuxSettings
+---@field enabled boolean
+---@field default_im? string
+---@field obtain_im_command? string|string[]
+---@field set_im_command? string|string[]
+
+--- Plugin options
+---@class PluginOptions
+---@field set_default_im_events string[]
+---@field save_im_events string[]
+---@field set_previous_im_events string[]
+---@field windows? WindowsSettings
+---@field mac? MacSettings
+---@field linux? LinuxSettings
+
+--- Default plugin options
+---@type PluginOptions
+local default_opts = {
+  set_default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+  set_previous_im_events = { "InsertEnter" },
+  save_im_events = { "InsertLeavePre" },
+  windows = {
+    enabled = false,
+  },
+  mac = {
+    enabled = false,
+  },
+  linux = {
+    enabled = false,
+  },
+}
+
+local M = {}
+
+--- Initialize plugin options
+---@param opts PluginOptions
+---@return PluginOptions
+function M.initialize_opts(opts)
+  -- Extend the opts with default_opts, overwriting nil values in opts with default_opts
+  return vim.tbl_extend("force", default_opts, opts)
+end
+
+--- Check if the plugin is enabled and all required settings are properly configured
+---@param opts PluginOptions
+---@return boolean
+function M.is_plugin_configured(opts)
+  local os = utils.detect_os()
+
+  if os == "wsl" or os == "windows" then
+    return opts.windows.enabled
+  elseif os == "mac" then
+    if opts.mac.enabled and not opts.mac.default_im then
+      error("The 'mac.default_im' field must be defined when mac plugin is enabled")
+      return false
+    end
+    return opts.mac.enabled
+  elseif os == "linux" then
+    if opts.linux.enabled then
+      local required_fields = { "default_im", "obtain_im_command", "set_im_command" }
+      for _, field in ipairs(required_fields) do
+        if not opts.linux[field] then
+          error(string.format("The 'linux.%s' field must be defined when linux plugin is enabled", field))
+          return false
+        end
+      end
+      return true
+    end
+    return false
+  else
+    error("Unsupported OS")
+  end
+end
+
+return M

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -5,7 +5,7 @@ local utils = require("im-switch.utils")
 ---@field enabled boolean
 
 --- macOS settings
----@class MacSettings
+---@class MacosSettings
 ---@field enabled boolean
 ---@field default_im? string
 
@@ -13,34 +13,75 @@ local utils = require("im-switch.utils")
 ---@class LinuxSettings
 ---@field enabled boolean
 ---@field default_im? string
----@field obtain_im_command? string|string[]
+---@field get_im_command? string|string[]
 ---@field set_im_command? string|string[]
 
 --- Plugin options
 ---@class PluginOptions
----@field set_default_im_events string[]
----@field save_im_events string[]
----@field set_previous_im_events string[]
+---@field default_im_events string[]
+---@field save_im_state_events string[]
+---@field restore_im_events string[]
 ---@field windows? WindowsSettings
----@field mac? MacSettings
+---@field macos? MacosSettings
 ---@field linux? LinuxSettings
 
 --- Default plugin options
 ---@type PluginOptions
 local default_opts = {
-  set_default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-  set_previous_im_events = { "InsertEnter" },
-  save_im_events = { "InsertLeavePre" },
+  -- Events that set the default input method.
+  default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+
+  -- Events that save the current input method state.
+  save_im_state_events = { "InsertLeavePre" },
+
+  -- Events that restore the previously saved input method.
+  restore_im_events = { "InsertEnter" },
+
+  -- Windows settings
   windows = {
+    -- Enable or disable the plugin on Windows/WSL2.
     enabled = false,
   },
-  mac = {
+
+  -- macOS settings
+  macos = {
+    -- Enable or disable the plugin on macOS.
     enabled = false,
+
+    -- The input method set when `default_im_events` is triggered.
+    default_im = "",
   },
+
+  -- Linux settings
   linux = {
+    -- Enable or disable the plugin on Linux.
     enabled = false,
+
+    -- The input method set when `default_im_events` is triggered.
+    default_im = "",
+
+    -- The command used to get the current input method when `save_im_state_events` is triggered.
+    get_im_command = {},
+
+    -- The command used to set the input method when `default_im_events` or `restore_im_events` is triggered.
+    set_im_command = {},
   },
 }
+
+--- Migrate a deprecated option to a new option name
+---@param new string
+---@param old string
+---@param opts PluginOptions
+local function migrate_option(new, old, opts)
+  if opts[old] ~= nil then
+    opts[new] = opts[old]
+    vim.notify(
+      string.format("[im-switch.nvim] '%s' is deprecated. Use '%s' instead.", old, new),
+      vim.log.levels.WARN,
+      { title = "im-switch.nvim" }
+    )
+  end
+end
 
 local M = {}
 
@@ -48,6 +89,13 @@ local M = {}
 ---@param opts PluginOptions
 ---@return PluginOptions
 function M.initialize_opts(opts)
+  -- NOTE: Migration from old to new options
+  migrate_option("macos", "mac", opts)
+  migrate_option("default_im_events", "set_default_im_events", opts)
+  migrate_option("restore_im_events", "set_previous_im_events", opts)
+  migrate_option("save_im_state_events", "save_im_events", opts)
+  migrate_option("get_im_command", "get_im_command", opts)
+
   -- Extend the opts with default_opts, overwriting nil values in opts with default_opts
   return vim.tbl_extend("force", default_opts, opts)
 end
@@ -60,15 +108,15 @@ function M.is_plugin_configured(opts)
 
   if os == "wsl" or os == "windows" then
     return opts.windows.enabled
-  elseif os == "mac" then
-    if opts.mac.enabled and not opts.mac.default_im then
-      error("The 'mac.default_im' field must be defined when mac plugin is enabled")
+  elseif os == "macos" then
+    if opts.macos.enabled and not opts.macos.default_im then
+      error("The 'macos.default_im' field must be defined when macos plugin is enabled")
       return false
     end
-    return opts.mac.enabled
+    return opts.macos.enabled
   elseif os == "linux" then
     if opts.linux.enabled then
-      local required_fields = { "default_im", "obtain_im_command", "set_im_command" }
+      local required_fields = { "default_im", "get_im_command", "set_im_command" }
       for _, field in ipairs(required_fields) do
         if not opts.linux[field] then
           error(string.format("The 'linux.%s' field must be defined when linux plugin is enabled", field))

--- a/lua/im-switch/utils.lua
+++ b/lua/im-switch/utils.lua
@@ -12,7 +12,7 @@ local function detect_os()
   elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
     return "windows"
   elseif vim.fn.has("mac") == 1 then
-    return "mac"
+    return "macos"
   elseif vim.fn.has("linux") == 1 then
     return "linux"
   else
@@ -46,7 +46,7 @@ local function get_executable_extension(is_prebuilt)
   local os = detect_os()
   if (os == "wsl") or (os == "windows") then
     return ".exe"
-  elseif os == "mac" then
+  elseif os == "macos" then
     if is_prebuilt == true then
       return ".bin"
     end
@@ -74,7 +74,7 @@ end
 --- @return boolean
 function M.should_build_with_cargo()
   local os = M.detect_os()
-  return (os == "mac") or (os == "windows")
+  return (os == "macos") or (os == "windows")
 end
 
 --- Get the built executable path in the release directory


### PR DESCRIPTION
Rename user options for consistency and clarity

- Renamed `set_default_im_events` to `default_im_events`
- Renamed `save_im_events` to `save_im_state_events`  
- Renamed `set_previous_im_events` to `restore_im_events`  
- Renamed `mac` to `macos` for consistency with `windows` and `linux`  
- Renamed `obtain_im_command` to `get_im_command`  

This is a breaking change. To avoid issues, ensure that your configuration uses the new option names.  