### PR TITLE
refactor: remove plenary dep, enabled option, and extract platform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It helps when you frequently switch between English and non-English IMs while co
 
 | OS            | Requirements |
 | ------------- | ------------ |
-| **All OS**    | Neovim >= **0.10.0**<br />[plenary.nvim](https://github.com/nvim-lua/plenary.nvim) |
+| **All OS**    | Neovim >= **0.10.0** |
 | **Linux**     | An input method framework (e.g., `fcitx5`, `ibus`) |
 
 > [!NOTE]
@@ -28,7 +28,6 @@ Install the plugin with your preferred package manager.
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
-{ "nvim-lua/plenary.nvim", lazy = true },
 {
   "drop-stones/im-switch.nvim",
   event = "VeryLazy",

--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ Install the plugin with your preferred package manager.
 
 ## 🚀 Quick Start
 
-Enable the plugin for your OS to switch to the default IM on InsertLeave.
+Configure the plugin for your OS to switch to the default IM on InsertLeave.
 
 ```lua
 require("im-switch").setup({
   macos = {
-    enabled = true,
     default_im = "com.apple.keylayout.ABC",
   },
 })
@@ -68,6 +67,8 @@ The CLI binary is automatically downloaded from [GitHub Releases](https://github
 
 ## ⚙️  Configuration
 
+The plugin is activated per-platform by adding the corresponding settings table.
+
 ### 🔧 General options
 
 | Key                  | Type     | Default | Description |
@@ -90,25 +91,27 @@ The CLI binary is automatically downloaded from [GitHub Releases](https://github
 
 #### 🪟 Windows/WSL2 (`windows`)
 
-| Key | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `windows.enabled` | `boolean` | `false` | Enable on Windows/WSL2 |
+Add the `windows` table to enable the plugin on Windows/WSL2. No additional options are needed.
+
+```lua
+require("im-switch").setup({
+  windows = {},
+})
+```
 
 #### 🍎 macOS (`macos`)
 
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `macos.enabled` | `boolean` | `false` | Enable on macOS |
-| `macos.default_im` | `string` | `""` | IM to set when `default_im_events` triggers (e.g., `"com.apple.keylayout.ABC"`) |
+| `macos.default_im` | `string` | — | IM to set when `default_im_events` triggers (e.g., `"com.apple.keylayout.ABC"`) |
 
 #### 🐧 Linux (`linux`)
 
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `linux.enabled` | `boolean` | `false` | Enable on Linux |
-| `linux.default_im` | `string` | `""` | IM to set when `default_im_events` triggers (framework-specific value) |
-| `linux.get_im_command` | `string[]?` | `{}` | Custom command to get current IM _(only needed for IM frameworks not supported by the CLI)_ |
-| `linux.set_im_command` | `string[]?` | `{}` | Custom command to set IM _(only needed for IM frameworks not supported by the CLI)_ |
+| `linux.default_im` | `string` | — | IM to set when `default_im_events` triggers (framework-specific value) |
+| `linux.get_im_command` | `string[]?` | — | Custom command to get current IM _(only needed for IM frameworks not supported by the CLI)_ |
+| `linux.set_im_command` | `string[]?` | — | Custom command to set IM _(only needed for IM frameworks not supported by the CLI)_ |
 
 On Linux, the plugin resolves IM switching in this order:
 
@@ -121,7 +124,6 @@ On Linux, the plugin resolves IM switching in this order:
 > ```lua
 > require("im-switch").setup({
 >   linux = {
->     enabled = true,
 >     default_im = "keyboard-us",
 >   },
 > })
@@ -135,62 +137,12 @@ On Linux, the plugin resolves IM switching in this order:
 > ```lua
 > require("im-switch").setup({
 >   linux = {
->     enabled = true,
 >     default_im = "default",
 >     get_im_command = { "my-im-tool", "get" },
 >     set_im_command = { "my-im-tool", "set" },
 >   },
 > })
 > ```
-
-<details><summary>Default options</summary>
-
-```lua
-{
-  -- Events that set the default input method.
-  default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-
-  -- Events that save the current input method.
-  save_im_state_events = { "InsertLeavePre" },
-
-  -- Events that restore the previously saved input method.
-  restore_im_events = { "InsertEnter" },
-
-  -- Windows settings
-  windows = {
-    -- Enable or disable the plugin on Windows/WSL2.
-    enabled = false,
-  },
-
-  -- macOS settings
-  macos = {
-    -- Enable or disable the plugin on macOS.
-    enabled = false,
-
-    -- The input method set when `default_im_events` is triggered.
-    default_im = "",
-  },
-
-  -- Linux settings
-  linux = {
-    -- Enable or disable the plugin on Linux.
-    enabled = false,
-
-    -- The input method set when `default_im_events` is triggered.
-    default_im = "",
-
-    -- Custom command to get the current input method (optional).
-    -- If set, takes priority over the im-switch CLI.
-    get_im_command = {},
-
-    -- Custom command to set the input method (optional).
-    -- If set, takes priority over the im-switch CLI.
-    set_im_command = {},
-  },
-}
-```
-
-</details>
 
 ## 🩺 Troubleshooting
 

--- a/doc/im-switch.nvim.txt
+++ b/doc/im-switch.nvim.txt
@@ -33,7 +33,7 @@ switch between English and non-English IMs while coding.
   -----------------------------------------------------------------------
   OS                                   Requirements
   ------------------------------------ ----------------------------------
-  All OS                               Neovim >= 0.10.0plenary.nvim
+  All OS                               Neovim >= 0.10.0
 
   Linux                                An input method framework (e.g.,
                                        fcitx5, ibus)
@@ -54,7 +54,6 @@ Install the plugin with your preferred package manager.
 LAZY.NVIM ~
 
 >lua
-    { "nvim-lua/plenary.nvim", lazy = true },
     {
       "drop-stones/im-switch.nvim",
       event = "VeryLazy",

--- a/doc/im-switch.nvim.txt
+++ b/doc/im-switch.nvim.txt
@@ -17,7 +17,7 @@ Table of Contents                           *im-switch.nvim-table-of-contents*
 1. im-switch.nvim                              *im-switch.nvim-im-switch.nvim*
 
 `im-switch.nvim` automatically switches your input method (IM) in Neovim based
-on events (e.g. `InsertLeave`, `InsertEnter`). It helps when you frequently
+on events (e.g. `InsertLeave`, `InsertEnter`). It helps when you frequently
 switch between English and non-English IMs while coding.
 
 
@@ -66,12 +66,11 @@ LAZY.NVIM ~
 
 🚀 QUICK START              *im-switch.nvim-im-switch.nvim-🚀-quick-start*
 
-Enable the plugin for your OS to switch to the default IM on InsertLeave.
+Configure the plugin for your OS to switch to the default IM on InsertLeave.
 
 >lua
     require("im-switch").setup({
       macos = {
-        enabled = true,
         default_im = "com.apple.keylayout.ABC",
       },
     })
@@ -97,6 +96,9 @@ The CLI binary is automatically downloaded from GitHub Releases
   Linux          x86_64, aarch64
 
 ⚙️ CONFIGURATION      *im-switch.nvim-im-switch.nvim-⚙️-configuration*
+
+The plugin is activated per-platform by adding the corresponding settings
+table.
 
 
 🔧 GENERAL OPTIONS ~
@@ -128,18 +130,21 @@ The CLI binary is automatically downloaded from GitHub Releases
 
 🪟 WINDOWS/WSL2 (WINDOWS)
 
-  Key               Type      Default   Description
-  ----------------- --------- --------- ------------------------
-  windows.enabled   boolean   false     Enable on Windows/WSL2
+Add the `windows` table to enable the plugin on Windows/WSL2. No additional
+options are needed.
+
+>lua
+    require("im-switch").setup({
+      windows = {},
+    })
+<
 
 🍎 MACOS (MACOS)
 
   ----------------------------------------------------------------------------------
   Key                Type        Default             Description
   ------------------ ----------- ------------------- -------------------------------
-  macos.enabled      boolean     false               Enable on macOS
-
-  macos.default_im   string      ""                  IM to set when
+  macos.default_im   string      —                   IM to set when
                                                      default_im_events triggers
                                                      (e.g.,
                                                      "com.apple.keylayout.ABC")
@@ -150,18 +155,16 @@ The CLI binary is automatically downloaded from GitHub Releases
   --------------------------------------------------------------------------------------
   Key                    Type        Default             Description
   ---------------------- ----------- ------------------- -------------------------------
-  linux.enabled          boolean     false               Enable on Linux
-
-  linux.default_im       string      ""                  IM to set when
+  linux.default_im       string      —                   IM to set when
                                                          default_im_events triggers
                                                          (framework-specific value)
 
-  linux.get_im_command   string[]?   {}                  Custom command to get current
+  linux.get_im_command   string[]?   —                   Custom command to get current
                                                          IM (only needed for IM
                                                          frameworks not supported by the
                                                          CLI)
 
-  linux.set_im_command   string[]?   {}                  Custom command to set IM (only
+  linux.set_im_command   string[]?   —                   Custom command to set IM (only
                                                          needed for IM frameworks not
                                                          supported by the CLI)
   --------------------------------------------------------------------------------------
@@ -175,7 +178,6 @@ On Linux, the plugin resolves IM switching in this order:
   >lua
       require("im-switch").setup({
         linux = {
-          enabled = true,
           default_im = "keyboard-us",
         },
       })
@@ -187,60 +189,12 @@ On Linux, the plugin resolves IM switching in this order:
   >lua
       require("im-switch").setup({
         linux = {
-          enabled = true,
           default_im = "default",
           get_im_command = { "my-im-tool", "get" },
           set_im_command = { "my-im-tool", "set" },
         },
       })
   <
-Default options ~
-
->lua
-    {
-      -- Events that set the default input method.
-      default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-    
-      -- Events that save the current input method.
-      save_im_state_events = { "InsertLeavePre" },
-    
-      -- Events that restore the previously saved input method.
-      restore_im_events = { "InsertEnter" },
-    
-      -- Windows settings
-      windows = {
-        -- Enable or disable the plugin on Windows/WSL2.
-        enabled = false,
-      },
-    
-      -- macOS settings
-      macos = {
-        -- Enable or disable the plugin on macOS.
-        enabled = false,
-    
-        -- The input method set when `default_im_events` is triggered.
-        default_im = "",
-      },
-    
-      -- Linux settings
-      linux = {
-        -- Enable or disable the plugin on Linux.
-        enabled = false,
-    
-        -- The input method set when `default_im_events` is triggered.
-        default_im = "",
-    
-        -- Custom command to get the current input method (optional).
-        -- If set, takes priority over the im-switch CLI.
-        get_im_command = {},
-    
-        -- Custom command to set the input method (optional).
-        -- If set, takes priority over the im-switch CLI.
-        set_im_command = {},
-      },
-    }
-<
-
 
 🩺 TROUBLESHOOTING      *im-switch.nvim-im-switch.nvim-🩺-troubleshooting*
 

--- a/lua/im-switch/build.lua
+++ b/lua/im-switch/build.lua
@@ -1,6 +1,6 @@
 local notify = require("im-switch.utils.notify")
-local os_utils = require("im-switch.utils.os")
 local path = require("im-switch.utils.path")
+local platforms = require("im-switch.platforms")
 local system = require("im-switch.utils.system")
 
 local DOWNLOAD_URL = "https://github.com/drop-stones/im-switch/releases/latest/download/im-switch-%s.tar.gz"
@@ -8,33 +8,32 @@ local REQUIRED_VERSION = { 0, 1, 0 }
 
 local M = {}
 
+---Get the CPU identifier for the current architecture.
+---@return string?, string?
+local function get_cpu()
+  local arch = jit and jit.arch:lower() or ""
+  if arch == "x64" or arch == "x86_64" then
+    return "x86_64"
+  elseif arch == "arm64" or arch == "aarch64" then
+    return "aarch64"
+  end
+  return nil, "Unsupported architecture: " .. arch
+end
+
 ---Get the Rust target triple for the current platform.
 ---@return string?, string?
 function M.get_target_triple()
-  local os_type, err = os_utils.get_os_type()
-  if err then
-    return nil, err
+  local cpu, cpu_err = get_cpu()
+  if cpu_err then
+    return nil, cpu_err
   end
 
-  local arch = jit and jit.arch:lower() or ""
-  local cpu
-  if arch == "x64" or arch == "x86_64" then
-    cpu = "x86_64"
-  elseif arch == "arm64" or arch == "aarch64" then
-    cpu = "aarch64"
-  else
-    return nil, "Unsupported architecture: " .. arch
+  local platform, plat_err = platforms.get_platform()
+  if plat_err then
+    return nil, plat_err
   end
 
-  if os_type == "windows" or os_type == "wsl" then
-    return cpu .. "-pc-windows-msvc"
-  elseif os_type == "macos" then
-    return cpu .. "-apple-darwin"
-  elseif os_type == "linux" then
-    return cpu .. "-unknown-linux-musl"
-  end
-
-  return nil, "Unsupported OS for download: " .. tostring(os_type)
+  return platform.target_triple(cpu)
 end
 
 ---Parse a semantic version string (e.g., "im-switch 0.1.0") into a table.
@@ -93,6 +92,12 @@ function M.setup()
     return
   end
 
+  local platform, plat_err = platforms.get_platform()
+  if plat_err then
+    notify.error("Failed to detect platform: " .. plat_err)
+    return
+  end
+
   local target, err = M.get_target_triple()
   if err then
     notify.error("Failed to detect target: " .. err)
@@ -130,15 +135,8 @@ function M.setup()
     return
   end
 
-  -- Set executable permissions (Unix only)
-  local os_type = os_utils.get_os_type()
-  if os_type ~= "windows" then
-    result = system.run_system({ "chmod", "+x", cli_path })
-    if result.code ~= 0 then
-      notify.error("Failed to set executable permissions: " .. result.stderr)
-      return
-    end
-  end
+  -- Platform-specific post-install (e.g., chmod +x on Unix)
+  platform.post_install(cli_path)
 
   -- Clean up archive
   os.remove(archive_path)

--- a/lua/im-switch/health.lua
+++ b/lua/im-switch/health.lua
@@ -26,8 +26,8 @@ end
 ---Check Linux-specific options and commands.
 ---@param opts table
 local function check_linux_config(opts)
-  if not opts.linux or not opts.linux.enabled then
-    vim.health.warn("Linux plugin is disabled")
+  if not opts.linux then
+    vim.health.warn("Linux plugin is not configured")
     return
   end
 
@@ -56,8 +56,8 @@ end
 ---Check macOS-specific options.
 ---@param opts table
 local function check_macos_config(opts)
-  if not opts.macos or not opts.macos.enabled then
-    vim.health.warn("macOS plugin is disabled")
+  if not opts.macos then
+    vim.health.warn("macOS plugin is not configured")
     return
   end
 
@@ -71,8 +71,8 @@ end
 ---Check Windows/WSL-specific options.
 ---@param opts table
 local function check_windows_config(opts)
-  if not opts.windows or not opts.windows.enabled then
-    vim.health.warn("Windows/WSL plugin is disabled")
+  if not opts.windows then
+    vim.health.warn("Windows/WSL plugin is not configured")
     return
   end
   vim.health.ok("Windows/WSL plugin is enabled")
@@ -94,12 +94,14 @@ local function check_binary()
     else
       vim.health.warn("im-switch CLI is not installed; using user-configured commands as fallback")
       local opts = options.get()
-      for _, key in ipairs({ "get_im_command", "set_im_command" }) do
-        local command_tbl = opts.linux[key]
-        if type(command_tbl) == "table" and #command_tbl > 0 then
-          check_command_exists(command_tbl[1])
-        else
-          vim.health.error("linux." .. key .. " is not configured")
+      if opts.linux then
+        for _, key in ipairs({ "get_im_command", "set_im_command" }) do
+          local command_tbl = opts.linux[key]
+          if type(command_tbl) == "table" and #command_tbl > 0 then
+            check_command_exists(command_tbl[1])
+          else
+            vim.health.error("linux." .. key .. " is not configured")
+          end
         end
       end
     end
@@ -132,10 +134,8 @@ local function check_os_options()
   end
 end
 
----Check for deprecated options and stale artifacts from older versions.
-local function check_deprecations()
-  local opts = options.get()
-
+---Check for stale artifacts from older versions.
+local function check_migration()
   -- Check for stale bin/ directory from the old embedded-Rust build
   local old_bin_dir = utils.path.get_plugin_path("bin")
   if vim.fn.isdirectory(old_bin_dir) == 1 then
@@ -145,22 +145,6 @@ local function check_deprecations()
     )
   else
     vim.health.ok("No stale artifacts from previous versions")
-  end
-
-  -- Check for deprecated 'enabled' option
-  local deprecated_platforms = {}
-  for _, platform in ipairs({ "windows", "macos", "linux" }) do
-    if opts[platform] and opts[platform].enabled ~= nil then
-      table.insert(deprecated_platforms, platform .. ".enabled")
-    end
-  end
-  if #deprecated_platforms > 0 then
-    vim.health.warn(
-      "Deprecated option(s): " .. table.concat(deprecated_platforms, ", "),
-      { "The 'enabled' option will be removed in a future release", "Remove 'enabled' from your config and rely on 'default_im' to activate each platform" }
-    )
-  else
-    vim.health.ok("No deprecated options detected")
   end
 end
 
@@ -172,6 +156,6 @@ return {
     check_binary()
 
     vim.health.start("im-switch.nvim: migration")
-    check_deprecations()
+    check_migration()
   end,
 }

--- a/lua/im-switch/health.lua
+++ b/lua/im-switch/health.lua
@@ -1,5 +1,5 @@
-local notify = require("im-switch.utils.notify")
 local options = require("im-switch.options")
+local platforms = require("im-switch.platforms")
 local utils = require("im-switch.utils")
 
 ---Check the current Neovim version.
@@ -13,130 +13,24 @@ local function check_nvim_version()
   end
 end
 
----Check if a command is executable.
----@param command string
-local function check_command_exists(command)
-  if vim.fn.executable(command) == 1 then
-    vim.health.ok(command .. " is executable")
-  else
-    vim.health.error(command .. " is not executable")
-  end
-end
-
----Check Linux-specific options and commands.
----@param opts table
-local function check_linux_config(opts)
-  if not opts.linux then
-    vim.health.warn("Linux plugin is not configured")
-    return
-  end
-
-  if type(opts.linux.default_im) == "string" and opts.linux.default_im ~= "" then
-    vim.health.ok("linux.default_im is set: " .. opts.linux.default_im)
-  else
-    vim.health.error("linux.default_im is not configured")
-  end
-
-  local cli_path = utils.path.get_cli_path()
-  if vim.fn.executable(cli_path) == 1 then
-    vim.health.ok("im-switch CLI is installed; linux.get_im_command/set_im_command are not required")
-  else
-    for _, key in ipairs({ "get_im_command", "set_im_command" }) do
-      local command_tbl = opts.linux[key]
-      if type(command_tbl) == "table" and #command_tbl > 0 then
-        vim.health.ok("linux." .. key .. " is set: " .. '"' .. table.concat(command_tbl, " ") .. '"')
-        check_command_exists(command_tbl[1])
-      else
-        vim.health.error("linux." .. key .. " is not configured and im-switch CLI is not installed")
-      end
-    end
-  end
-end
-
----Check macOS-specific options.
----@param opts table
-local function check_macos_config(opts)
-  if not opts.macos then
-    vim.health.warn("macOS plugin is not configured")
-    return
-  end
-
-  if type(opts.macos.default_im) == "string" and opts.macos.default_im ~= "" then
-    vim.health.ok("macos.default_im is set: " .. opts.macos.default_im)
-  else
-    vim.health.error("macos.default_im is not configured")
-  end
-end
-
----Check Windows/WSL-specific options.
----@param opts table
-local function check_windows_config(opts)
-  if not opts.windows then
-    vim.health.warn("Windows/WSL plugin is not configured")
-    return
-  end
-  vim.health.ok("Windows/WSL plugin is enabled")
-end
-
----Check the availability of the im-switch CLI binary.
-local function check_binary()
-  local os_type, err = utils.os.get_os_type()
+---Run platform-specific health checks.
+local function check_platform()
+  local platform, err = platforms.get_platform()
   if err then
-    notify.error(err)
+    vim.health.error("Failed to detect platform: " .. err)
     return
   end
-
-  local cli_path = utils.path.get_cli_path()
-
-  if os_type == "linux" then
-    if vim.fn.executable(cli_path) == 1 then
-      vim.health.ok("im-switch CLI is installed at " .. cli_path)
-    else
-      vim.health.warn("im-switch CLI is not installed; using user-configured commands as fallback")
-      local opts = options.get()
-      if opts.linux then
-        for _, key in ipairs({ "get_im_command", "set_im_command" }) do
-          local command_tbl = opts.linux[key]
-          if type(command_tbl) == "table" and #command_tbl > 0 then
-            check_command_exists(command_tbl[1])
-          else
-            vim.health.error("linux." .. key .. " is not configured")
-          end
-        end
-      end
-    end
-  else
-    if vim.fn.executable(cli_path) == 1 then
-      vim.health.ok("im-switch CLI is installed at " .. cli_path)
-    else
-      vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (run :Lazy build im-switch.nvim)")
-    end
-  end
-end
-
----Check and report plugin status based on OS-specific options.
-local function check_os_options()
-  local os_type, err = utils.os.get_os_type()
-  if err then
-    notify.error(err)
+  if not platform then
+    vim.health.warn("Unknown platform")
     return
   end
 
   local opts = options.get()
-  if os_type == "linux" then
-    check_linux_config(opts)
-  elseif os_type == "macos" then
-    check_macos_config(opts)
-  elseif os_type == "windows" or os_type == "wsl" then
-    check_windows_config(opts)
-  else
-    vim.health.warn("Unknown OS: " .. tostring(os_type))
-  end
+  platform.check_health(opts)
 end
 
 ---Check for stale artifacts from older versions.
 local function check_migration()
-  -- Check for stale bin/ directory from the old embedded-Rust build
   local old_bin_dir = utils.path.get_plugin_path("bin")
   if vim.fn.isdirectory(old_bin_dir) == 1 then
     vim.health.warn(
@@ -152,8 +46,7 @@ return {
   check = function()
     vim.health.start("im-switch.nvim")
     check_nvim_version()
-    check_os_options()
-    check_binary()
+    check_platform()
 
     vim.health.start("im-switch.nvim: migration")
     check_migration()

--- a/lua/im-switch/health.lua
+++ b/lua/im-switch/health.lua
@@ -2,16 +2,6 @@ local notify = require("im-switch.utils.notify")
 local options = require("im-switch.options")
 local utils = require("im-switch.utils")
 
----Check if plenary.nvim is installed.
-local function check_plenary()
-  local ok, _ = pcall(require, "plenary")
-  if ok then
-    vim.health.ok("plenary.nvim is installed")
-  else
-    vim.health.error("plenary.nvim is not installed")
-  end
-end
-
 ---Check the current Neovim version.
 local function check_nvim_version()
   local version = vim.version()
@@ -177,7 +167,6 @@ end
 return {
   check = function()
     vim.health.start("im-switch.nvim")
-    check_plenary()
     check_nvim_version()
     check_os_options()
     check_binary()

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -12,36 +12,6 @@ local default_opts = {
 
   -- Events that restore the previously saved input method.
   restore_im_events = { "InsertEnter" },
-
-  -- Windows settings
-  windows = {
-    -- Enable or disable the plugin on Windows/WSL2.
-    enabled = false,
-  },
-
-  -- macOS settings
-  macos = {
-    -- Enable or disable the plugin on macOS.
-    enabled = false,
-
-    -- The input method set when `default_im_events` is triggered.
-    default_im = "",
-  },
-
-  -- Linux settings
-  linux = {
-    -- Enable or disable the plugin on Linux.
-    enabled = false,
-
-    -- The input method set when `default_im_events` is triggered.
-    default_im = "",
-
-    -- The command used to get the current input method when `save_im_state_events` is triggered.
-    get_im_command = {},
-
-    -- The command used to set the input method when `default_im_events` or `restore_im_events` is triggered.
-    set_im_command = {},
-  },
 }
 
 local M = {}
@@ -71,13 +41,14 @@ function M.validate_options(opts)
     return false
   end
 
-  if opts.macos and opts.macos.enabled and not opts.macos.default_im then
-    notify.error("The 'macos.default_im' field must be defined when macos plugin is enabled")
+  if opts.macos and (not opts.macos.default_im or opts.macos.default_im == "") then
+    notify.error("'macos.default_im' is required when macos is configured")
     return false
   end
-  if opts.linux and opts.linux.enabled then
-    if not opts.linux.default_im then
-      notify.error("The 'linux.default_im' field must be defined when linux plugin is enabled")
+
+  if opts.linux then
+    if not opts.linux.default_im or opts.linux.default_im == "" then
+      notify.error("'linux.default_im' is required when linux is configured")
       return false
     end
     -- get_im_command/set_im_command are only required when im-switch CLI is not installed
@@ -87,7 +58,7 @@ function M.validate_options(opts)
         if not opts.linux[field] or #opts.linux[field] == 0 then
           notify.error(
             string.format(
-              "The 'linux.%s' field must be defined when linux plugin is enabled and im-switch CLI is not installed",
+              "'linux.%s' is required when im-switch CLI is not installed",
               field
             )
           )
@@ -109,13 +80,11 @@ function M.is_plugin_enabled(opts)
   end
 
   if os_type == "windows" or os_type == "wsl" then
-    return opts.windows and opts.windows.enabled
+    return opts.windows ~= nil
   elseif os_type == "macos" then
-    return opts.macos and opts.macos.enabled and opts.macos.default_im ~= nil
+    return opts.macos ~= nil
   elseif os_type == "linux" then
-    return opts.linux
-      and opts.linux.enabled
-      and opts.linux.default_im ~= nil
+    return opts.linux ~= nil
   end
   return false
 end

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -1,5 +1,4 @@
-local notify = require("im-switch.utils.notify")
-local os_utils = require("im-switch.utils.os")
+local platforms = require("im-switch.platforms")
 
 --- Default plugin options
 ---@type PluginOptions
@@ -37,56 +36,27 @@ end
 ---@return boolean
 function M.validate_options(opts)
   if type(opts) ~= "table" then
-    notify.error("Options must be a table")
+    require("im-switch.utils.notify").error("Options must be a table")
     return false
   end
 
-  if opts.macos and (not opts.macos.default_im or opts.macos.default_im == "") then
-    notify.error("'macos.default_im' is required when macos is configured")
-    return false
+  local platform = platforms.get_platform()
+  if not platform then
+    return true
   end
 
-  if opts.linux then
-    if not opts.linux.default_im or opts.linux.default_im == "" then
-      notify.error("'linux.default_im' is required when linux is configured")
-      return false
-    end
-    -- get_im_command/set_im_command are only required when im-switch CLI is not installed
-    local path = require("im-switch.utils.path")
-    if vim.fn.executable(path.get_cli_path()) ~= 1 then
-      for _, field in ipairs({ "get_im_command", "set_im_command" }) do
-        if not opts.linux[field] or #opts.linux[field] == 0 then
-          notify.error(
-            string.format(
-              "'linux.%s' is required when im-switch CLI is not installed",
-              field
-            )
-          )
-          return false
-        end
-      end
-    end
-  end
-  return true
+  return platform.validate(opts)
 end
 
 ---Check if the plugin should be enabled for the current OS and options.
 ---@param opts table
 ---@return boolean
 function M.is_plugin_enabled(opts)
-  local os_type, err = os_utils.get_os_type()
-  if err then
+  local platform = platforms.get_platform()
+  if not platform then
     return false
   end
-
-  if os_type == "windows" or os_type == "wsl" then
-    return opts.windows ~= nil
-  elseif os_type == "macos" then
-    return opts.macos ~= nil
-  elseif os_type == "linux" then
-    return opts.linux ~= nil
-  end
-  return false
+  return opts[platform.opts_key] ~= nil
 end
 
 return M

--- a/lua/im-switch/platforms/init.lua
+++ b/lua/im-switch/platforms/init.lua
@@ -1,0 +1,24 @@
+local os_utils = require("im-switch.utils.os")
+
+local M = {}
+
+---Get the platform module for the current OS.
+---@return table?, string?
+function M.get_platform()
+  local os_type, err = os_utils.get_os_type()
+  if err then
+    return nil, err
+  end
+
+  if os_type == "windows" or os_type == "wsl" then
+    return require("im-switch.platforms.windows")
+  elseif os_type == "macos" then
+    return require("im-switch.platforms.macos")
+  elseif os_type == "linux" then
+    return require("im-switch.platforms.linux")
+  end
+
+  return nil, "Unsupported OS: " .. tostring(os_type)
+end
+
+return M

--- a/lua/im-switch/platforms/linux.lua
+++ b/lua/im-switch/platforms/linux.lua
@@ -1,0 +1,143 @@
+local path = require("im-switch.utils.path")
+
+local M = {}
+
+M.opts_key = "linux"
+
+---Cached result of whether the installed im-switch CLI binary exists.
+---@type boolean?
+local cli_exists_cache = nil
+
+---Check if the im-switch CLI binary exists at the install location (cached).
+---@return boolean
+local function is_cli_installed()
+  if cli_exists_cache == nil then
+    cli_exists_cache = vim.fn.executable(path.get_cli_path()) == 1
+  end
+  return cli_exists_cache
+end
+
+---Check if user-configured custom commands are set.
+---@param opts table
+---@return boolean
+local function has_custom_commands(opts)
+  return opts.linux.get_im_command
+    and #opts.linux.get_im_command > 0
+    and opts.linux.set_im_command
+    and #opts.linux.set_im_command > 0
+end
+
+---Reset the CLI existence cache. Used in tests.
+function M._reset_cache()
+  cli_exists_cache = nil
+end
+
+---@param action "get"|"set"
+---@param im_value? string
+---@param opts table
+---@return string[]?, string?
+function M.get_im_command(action, im_value, opts)
+  -- User-configured commands take priority
+  if has_custom_commands(opts) then
+    if action == "get" then
+      return opts.linux.get_im_command
+    elseif action == "set" then
+      local command = vim.deepcopy(opts.linux.set_im_command)
+      table.insert(command, im_value)
+      return command
+    end
+    return nil, "Unsupported action for Linux: " .. tostring(action)
+  end
+
+  -- Fall back to im-switch CLI
+  if is_cli_installed() then
+    local cli = path.get_cli_path()
+    if action == "get" then
+      return { cli, "get" }
+    elseif action == "set" then
+      return { cli, "set", im_value }
+    end
+    return nil, "Unsupported action for Linux: " .. tostring(action)
+  end
+
+  return nil, "No im-switch CLI installed and no custom commands configured for Linux"
+end
+
+---@param opts table
+---@return string
+function M.default_im_value(opts)
+  return opts.linux.default_im
+end
+
+---@param opts table
+---@return boolean
+function M.validate(opts)
+  if not opts.linux then
+    return true
+  end
+  local notify = require("im-switch.utils.notify")
+  if not opts.linux.default_im or opts.linux.default_im == "" then
+    notify.error("'linux.default_im' is required when linux is configured")
+    return false
+  end
+  -- get_im_command/set_im_command are only required when im-switch CLI is not installed
+  if not is_cli_installed() and not has_custom_commands(opts) then
+    notify.error("'linux.get_im_command' and 'linux.set_im_command' are required when im-switch CLI is not installed")
+    return false
+  end
+  return true
+end
+
+---@param opts table
+function M.check_health(opts)
+  if not opts.linux then
+    vim.health.warn("Linux plugin is not configured")
+    return
+  end
+
+  if type(opts.linux.default_im) == "string" and opts.linux.default_im ~= "" then
+    vim.health.ok("linux.default_im is set: " .. opts.linux.default_im)
+  else
+    vim.health.error("linux.default_im is not configured")
+  end
+
+  local cli_path = path.get_cli_path()
+  if vim.fn.executable(cli_path) == 1 then
+    vim.health.ok("im-switch CLI is installed at " .. cli_path)
+    if has_custom_commands(opts) then
+      vim.health.ok("Custom commands are configured and take priority over CLI")
+    end
+  else
+    if has_custom_commands(opts) then
+      vim.health.ok("Using custom commands (im-switch CLI is not installed)")
+      for _, key in ipairs({ "get_im_command", "set_im_command" }) do
+        local cmd = opts.linux[key]
+        vim.health.ok("linux." .. key .. " is set: " .. '"' .. table.concat(cmd, " ") .. '"')
+        if vim.fn.executable(cmd[1]) == 1 then
+          vim.health.ok(cmd[1] .. " is executable")
+        else
+          vim.health.error(cmd[1] .. " is not executable")
+        end
+      end
+    else
+      vim.health.error("im-switch CLI is not installed and no custom commands configured")
+    end
+  end
+end
+
+---@param cpu string
+---@return string
+function M.target_triple(cpu)
+  return cpu .. "-unknown-linux-musl"
+end
+
+---@param cli_path string
+function M.post_install(cli_path)
+  local system = require("im-switch.utils.system")
+  local result = system.run_system({ "chmod", "+x", cli_path })
+  if result.code ~= 0 then
+    require("im-switch.utils.notify").error("Failed to set executable permissions: " .. result.stderr)
+  end
+end
+
+return M

--- a/lua/im-switch/platforms/macos.lua
+++ b/lua/im-switch/platforms/macos.lua
@@ -54,7 +54,7 @@ function M.check_health(opts)
   if vim.fn.executable(cli_path) == 1 then
     vim.health.ok("im-switch CLI is installed at " .. cli_path)
   else
-    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (run :Lazy build im-switch.nvim)")
+    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)")
   end
 end
 

--- a/lua/im-switch/platforms/macos.lua
+++ b/lua/im-switch/platforms/macos.lua
@@ -1,0 +1,76 @@
+local path = require("im-switch.utils.path")
+
+local M = {}
+
+M.opts_key = "macos"
+
+---@param action "get"|"set"
+---@param im_value? string
+---@param _opts table
+---@return string[]?, string?
+function M.get_im_command(action, im_value, _opts)
+  local cli = path.get_cli_path()
+  if action == "get" then
+    return { cli, "get" }
+  elseif action == "set" then
+    return { cli, "set", im_value }
+  end
+  return nil, "Unsupported action for macOS: " .. tostring(action)
+end
+
+---@param opts table
+---@return string
+function M.default_im_value(opts)
+  return opts.macos.default_im
+end
+
+---@param opts table
+---@return boolean
+function M.validate(opts)
+  if not opts.macos then
+    return true
+  end
+  if not opts.macos.default_im or opts.macos.default_im == "" then
+    require("im-switch.utils.notify").error("'macos.default_im' is required when macos is configured")
+    return false
+  end
+  return true
+end
+
+---@param opts table
+function M.check_health(opts)
+  if not opts.macos then
+    vim.health.warn("macOS plugin is not configured")
+    return
+  end
+
+  if type(opts.macos.default_im) == "string" and opts.macos.default_im ~= "" then
+    vim.health.ok("macos.default_im is set: " .. opts.macos.default_im)
+  else
+    vim.health.error("macos.default_im is not configured")
+  end
+
+  local cli_path = path.get_cli_path()
+  if vim.fn.executable(cli_path) == 1 then
+    vim.health.ok("im-switch CLI is installed at " .. cli_path)
+  else
+    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (run :Lazy build im-switch.nvim)")
+  end
+end
+
+---@param cpu string
+---@return string
+function M.target_triple(cpu)
+  return cpu .. "-apple-darwin"
+end
+
+---@param cli_path string
+function M.post_install(cli_path)
+  local system = require("im-switch.utils.system")
+  local result = system.run_system({ "chmod", "+x", cli_path })
+  if result.code ~= 0 then
+    require("im-switch.utils.notify").error("Failed to set executable permissions: " .. result.stderr)
+  end
+end
+
+return M

--- a/lua/im-switch/platforms/windows.lua
+++ b/lua/im-switch/platforms/windows.lua
@@ -32,7 +32,7 @@ end
 ---@return boolean
 function M.validate(opts)
   -- No additional validation needed for Windows
-  return opts.windows ~= nil
+  return true
 end
 
 ---@param opts table
@@ -47,7 +47,7 @@ function M.check_health(opts)
   if vim.fn.executable(cli_path) == 1 then
     vim.health.ok("im-switch CLI is installed at " .. cli_path)
   else
-    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (run :Lazy build im-switch.nvim)")
+    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)")
   end
 end
 

--- a/lua/im-switch/platforms/windows.lua
+++ b/lua/im-switch/platforms/windows.lua
@@ -1,0 +1,65 @@
+local path = require("im-switch.utils.path")
+
+local M = {}
+
+M.opts_key = "windows"
+
+---@param action "get"|"set"
+---@param im_value? string
+---@param _opts table
+---@return string[]?, string?
+function M.get_im_command(action, im_value, _opts)
+  local cli = path.get_cli_path()
+  if action == "get" then
+    return { cli, "ime", "get" }
+  elseif action == "set" then
+    if im_value == "enabled" then
+      return { cli, "ime", "enable" }
+    else
+      return { cli, "ime", "disable" }
+    end
+  end
+  return nil, "Unsupported action for Windows/WSL: " .. tostring(action)
+end
+
+---@param _opts table
+---@return string
+function M.default_im_value(_opts)
+  return "disabled"
+end
+
+---@param opts table
+---@return boolean
+function M.validate(opts)
+  -- No additional validation needed for Windows
+  return opts.windows ~= nil
+end
+
+---@param opts table
+function M.check_health(opts)
+  if not opts.windows then
+    vim.health.warn("Windows/WSL plugin is not configured")
+    return
+  end
+  vim.health.ok("Windows/WSL plugin is enabled")
+
+  local cli_path = path.get_cli_path()
+  if vim.fn.executable(cli_path) == 1 then
+    vim.health.ok("im-switch CLI is installed at " .. cli_path)
+  else
+    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (run :Lazy build im-switch.nvim)")
+  end
+end
+
+---@param cpu string
+---@return string
+function M.target_triple(cpu)
+  return cpu .. "-pc-windows-msvc"
+end
+
+---@param _cli_path string
+function M.post_install(_cli_path)
+  -- No post-install steps needed on Windows
+end
+
+return M

--- a/lua/im-switch/types.lua
+++ b/lua/im-switch/types.lua
@@ -1,15 +1,12 @@
---- Windows settings
+--- Windows settings (presence of this table enables the plugin on Windows/WSL2)
 ---@class WindowsSettings
----@field enabled boolean
 
 --- macOS settings
 ---@class MacosSettings
----@field enabled boolean
 ---@field default_im string
 
 --- Linux settings
 ---@class LinuxSettings
----@field enabled boolean
 ---@field default_im string
 ---@field get_im_command? string[]
 ---@field set_im_command? string[]
@@ -19,6 +16,6 @@
 ---@field default_im_events string[] Events to set default input method
 ---@field save_im_state_events string[]  Events to save IM state
 ---@field restore_im_events string[] Events to restore IM state
----@field windows WindowsSettings
----@field macos MacosSettings
----@field linux LinuxSettings
+---@field windows? WindowsSettings
+---@field macos? MacosSettings
+---@field linux? LinuxSettings

--- a/lua/im-switch/utils/im_command.lua
+++ b/lua/im-switch/utils/im_command.lua
@@ -1,106 +1,13 @@
-local os_utils = require("im-switch.utils.os")
-local path = require("im-switch.utils.path")
-
-local ERRORS = {
-  invalid_args = "Invalid arguments: action is required",
-  invalid_action = "Unsupported action for %s: %s",
-  invalid_os = "Unsupported OS: %s",
-}
-
----Cached result of whether the installed im-switch CLI binary exists.
----@type boolean?
-local cli_exists_cache = nil
-
----Check if the im-switch CLI binary exists at the install location (cached).
----@return boolean
-local function is_cli_installed()
-  if cli_exists_cache == nil then
-    cli_exists_cache = vim.fn.executable(path.get_cli_path()) == 1
-  end
-  return cli_exists_cache
-end
+local platforms = require("im-switch.platforms")
 
 local M = {}
 
----Reset the CLI existence cache. Used in tests.
+---Reset the CLI existence cache (Linux). Used in tests.
 function M._reset_cache()
-  cli_exists_cache = nil
-end
-
----Generate the command for Windows/WSL to get/set input method.
----Uses the `ime` subcommand of the external im-switch CLI.
----@param action "get"|"set"
----@param im_value? string
----@return string[]?, string?
-local function get_windows_command(action, im_value)
-  local cli = path.get_cli_path()
-  if action == "get" then
-    return { cli, "ime", "get" }
-  elseif action == "set" then
-    if im_value == "enabled" then
-      return { cli, "ime", "enable" }
-    else
-      return { cli, "ime", "disable" }
-    end
+  local ok, linux = pcall(require, "im-switch.platforms.linux")
+  if ok then
+    linux._reset_cache()
   end
-  return nil, string.format(ERRORS.invalid_action, "Windows/WSL", tostring(action))
-end
-
----Generate the command for macOS to get/set input method.
----@param action "get"|"set"
----@param im_value? string
----@return string[]?, string?
-local function get_macos_command(action, im_value)
-  local cli = path.get_cli_path()
-  if action == "get" then
-    return { cli, "get" }
-  elseif action == "set" then
-    return { cli, "set", im_value }
-  end
-  return nil, string.format(ERRORS.invalid_action, "macOS", tostring(action))
-end
-
----Check if user-configured custom commands are set for Linux.
----@param opts table
----@return boolean
-local function has_custom_commands(opts)
-  return opts.linux.get_im_command
-    and #opts.linux.get_im_command > 0
-    and opts.linux.set_im_command
-    and #opts.linux.set_im_command > 0
-end
-
----Generate the command for Linux to get/set input method.
----User-configured commands take priority over the im-switch CLI.
----@param action "get"|"set"
----@param im_value? string
----@param opts table
----@return string[]?, string?
-local function get_linux_command(action, im_value, opts)
-  -- User-configured commands take priority
-  if has_custom_commands(opts) then
-    if action == "get" then
-      return opts.linux.get_im_command
-    elseif action == "set" then
-      local command = vim.deepcopy(opts.linux.set_im_command)
-      table.insert(command, im_value)
-      return command
-    end
-    return nil, string.format(ERRORS.invalid_action, "Linux", tostring(action))
-  end
-
-  -- Fall back to im-switch CLI
-  if is_cli_installed() then
-    local cli = path.get_cli_path()
-    if action == "get" then
-      return { cli, "get" }
-    elseif action == "set" then
-      return { cli, "set", im_value }
-    end
-    return nil, string.format(ERRORS.invalid_action, "Linux", tostring(action))
-  end
-
-  return nil, "No im-switch CLI installed and no custom commands configured for Linux"
 end
 
 ---Generate the command to get/set input method based on OS and options.
@@ -110,34 +17,21 @@ end
 ---@return string[]?, string?
 function M.get_im_command(action, im_value)
   if not action then
-    return nil, ERRORS.invalid_args
+    return nil, "Invalid arguments: action is required"
   end
 
-  local opts = require("im-switch.options").get()
-  local os_type, err = os_utils.get_os_type()
+  local platform, err = platforms.get_platform()
   if err then
     return nil, err
   end
 
+  local opts = require("im-switch.options").get()
+
   if action == "set" and not im_value then
-    if os_type == "macos" then
-      im_value = opts.macos.default_im
-    elseif os_type == "linux" then
-      im_value = opts.linux.default_im
-    elseif os_type == "windows" or os_type == "wsl" then
-      im_value = "disabled"
-    end
+    im_value = platform.default_im_value(opts)
   end
 
-  if os_type == "wsl" or os_type == "windows" then
-    return get_windows_command(action, im_value)
-  elseif os_type == "macos" then
-    return get_macos_command(action, im_value)
-  elseif os_type == "linux" then
-    return get_linux_command(action, im_value, opts)
-  end
-
-  return nil, string.format(ERRORS.invalid_os, tostring(os_type))
+  return platform.get_im_command(action, im_value, opts)
 end
 
 return M

--- a/lua/im-switch/utils/path.lua
+++ b/lua/im-switch/utils/path.lua
@@ -1,48 +1,46 @@
-local Path = require("plenary.path")
 local notify = require("im-switch.utils.notify")
 local os_utils = require("im-switch.utils.os")
 local system = require("im-switch.utils.system")
 
----@type Path?
+---@type string?
 local cached_plugin_root_path = nil
 
 ---Get the root path of the plugin using git, or fallback to parent directory
----@return Path the root path
+---@return string
 local function get_plugin_root_path()
   if cached_plugin_root_path then
     return cached_plugin_root_path
   end
 
-  local path = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
-  local result = system.run_system({ "git", "rev-parse", "--show-toplevel" }, { cwd = path })
+  local this_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
+  local result = system.run_system({ "git", "rev-parse", "--show-toplevel" }, { cwd = this_dir })
 
   if result.code ~= 0 then
-    local fallback = vim.fn.fnamemodify(path, ":h:h")
-    notify.error("Git command failed in directory: " .. path)
+    -- Fallback: this file is at lua/im-switch/utils/path.lua, so root is 4 levels up
+    local fallback = vim.fn.fnamemodify(this_dir, ":h:h:h")
+    notify.error("Git command failed in directory: " .. this_dir)
     notify.error("Error: " .. result.stderr)
     notify.warn("Falling back to: " .. fallback)
-    cached_plugin_root_path = Path:new(fallback)
+    cached_plugin_root_path = fallback
     return cached_plugin_root_path
   end
 
-  local root_path = vim.trim(result.stdout)
-  cached_plugin_root_path = Path:new(root_path)
+  cached_plugin_root_path = vim.trim(result.stdout)
   return cached_plugin_root_path
 end
 
 local M = {}
 
----Get a Path object for the plugin root or a subpath under it
+---Get the plugin root path or a subpath under it
 ---@param ... string  -- subpaths under root
 ---@return string
 function M.get_plugin_path(...)
   local root = get_plugin_root_path()
   local args = { ... }
   if #args == 0 then
-    return root:absolute()
-  else
-    return root:joinpath(unpack(args)):absolute()
+    return root
   end
+  return vim.fs.joinpath(root, unpack(args))
 end
 
 ---Get the install directory for the im-switch CLI binary.

--- a/lua/im-switch/utils/path.lua
+++ b/lua/im-switch/utils/path.lua
@@ -16,7 +16,7 @@ local function get_plugin_root_path()
   local result = system.run_system({ "git", "rev-parse", "--show-toplevel" }, { cwd = this_dir })
 
   if result.code ~= 0 then
-    -- Fallback: this file is at lua/im-switch/utils/path.lua, so root is 4 levels up
+    -- Fallback: this file is at lua/im-switch/utils/path.lua, so root is 3 levels up
     local fallback = vim.fn.fnamemodify(this_dir, ":h:h:h")
     notify.error("Git command failed in directory: " .. this_dir)
     notify.error("Error: " .. result.stderr)

--- a/tests/lua/minimal_init.lua
+++ b/tests/lua/minimal_init.lua
@@ -1,6 +1,7 @@
 --[[
 minimal_init.lua
 Test bootstrap file for setting up the test environment.
+Ensures plenary.nvim is installed as a dev dependency for the test runner.
 ]]
 
 -- Get the plugin root directory
@@ -10,3 +11,11 @@ local plugin_root = vim.fn.fnamemodify(script_path, ":h:h:h")
 
 -- Prepend plugin root to runtimepath
 vim.opt.runtimepath:prepend(plugin_root)
+
+-- Install plenary.nvim (dev dependency for test runner) if not present
+local plenary_path = vim.fn.fnamemodify(plugin_root, ":h") .. "/plenary.nvim"
+if vim.fn.isdirectory(plenary_path) == 0 then
+  print("Installing plenary.nvim for testing...")
+  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/nvim-lua/plenary.nvim", plenary_path })
+end
+vim.opt.runtimepath:prepend(plenary_path)

--- a/tests/lua/minimal_init.lua
+++ b/tests/lua/minimal_init.lua
@@ -1,7 +1,6 @@
 --[[
 minimal_init.lua
 Test bootstrap file for setting up the test environment.
-Ensures plenary.nvim is installed and added to runtimepath for all tests.
 ]]
 
 -- Get the plugin root directory
@@ -9,14 +8,5 @@ local info = debug.getinfo(1, "S")
 local script_path = info.source:sub(2)
 local plugin_root = vim.fn.fnamemodify(script_path, ":h:h:h")
 
--- Set plenary.nvim path to the parent of the plugin root (i.e., plugin_root/..)
-local plenary_path = vim.fn.fnamemodify(plugin_root, ":h") .. "/plenary.nvim"
-
--- Install plenary.nvim if not present
-if vim.fn.isdirectory(plenary_path) == 0 then
-  print("Installing plenary.nvim for testing...")
-  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/nvim-lua/plenary.nvim", plenary_path })
-end
-
--- Prepend plenary.nvim to runtimepath
-vim.opt.runtimepath:prepend(plenary_path)
+-- Prepend plugin root to runtimepath
+vim.opt.runtimepath:prepend(plugin_root)


### PR DESCRIPTION
## Summary

- **Remove plenary.nvim runtime dependency** — Replace `plenary.path` with `vim.fs.joinpath` and plain strings. Plenary remains as a dev dependency for the test runner only.
- **Remove `enabled` option** — Plugin is now activated per-platform by the presence of the settings table (e.g. `windows = {}`, `macos = { default_im = "..." }`). The `enabled` option is silently ignored for backward compatibility.
- **Extract platform-specific logic** — Move IM command generation, validation, health checks, build target triple, and post-install steps into `platforms/windows.lua`, `macos.lua`, and `linux.lua` with a common interface. Core files now delegate to the platform module with no OS branching.

## Test plan

- [x] All 44 unit tests pass
- [ ] Verify `:checkhealth im-switch` reports correctly
- [ ] Verify IM switching works on the current platform
- [ ] Verify plugin activates without `enabled = true` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)