### PR TITLE
feat(options): replace event config with mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,24 @@ Install the plugin with your preferred package manager.
 }
 ```
 
-## 🚀 Quick Start
+## ⚙️ Configuration
 
-Configure the plugin for your OS to switch to the default IM on InsertLeave.
+### General options
+
+| Key | Type | Default | Description |
+| --- | ---- | ------- | ----------- |
+| `mode` | `string` | `"restore"` | IM switching mode |
+
+Available modes:
+
+- **`"restore"`** (default) — Saves IM state per buffer on `InsertLeave` and restores it on `InsertEnter`.
+- **`"fixed"`** — Always switches to the default IM. No save/restore.
+
+### macOS
+
+| Key | Type | Required | Description |
+| --- | ---- | -------- | ----------- |
+| `macos.default_im` | `string` | Yes | Default IM to switch to when leaving insert/cmdline mode |
 
 ```lua
 require("im-switch").setup({
@@ -48,6 +63,33 @@ require("im-switch").setup({
   },
 })
 ```
+
+### Linux
+
+| Key | Type | Required | Description |
+| --- | ---- | -------- | ----------- |
+| `linux.default_im` | `string` | Yes | Default IM to switch to when leaving insert/cmdline mode |
+| `linux.get_im_command` | `string[]` | No | Custom command to get current IM (takes priority over CLI if set) |
+| `linux.set_im_command` | `string[]` | No | Custom command to set IM (takes priority over CLI if set) |
+
+```lua
+require("im-switch").setup({
+  linux = {
+    default_im = "keyboard-us",
+  },
+})
+```
+
+> [!TIP]
+> If your IM framework is not supported by the [`im-switch`](https://github.com/drop-stones/im-switch) CLI, you can use custom commands:
+>
+> ```lua
+> linux = {
+>   default_im = "default",
+>   get_im_command = { "my-im-tool", "get" },
+>   set_im_command = { "my-im-tool", "set" },
+> }
+> ```
 
 ## 🔄 How it switches IM
 
@@ -64,78 +106,6 @@ The CLI binary is automatically downloaded from [GitHub Releases](https://github
 | Windows/WSL2 | x86_64, aarch64   |
 | macOS        | x86_64, aarch64   |
 | Linux        | x86_64, aarch64   |
-
-## ⚙️  Configuration
-
-### 🔧 General options
-
-| Key    | Type     | Default     | Description |
-| ------ | -------- | ----------- | ----------- |
-| `mode` | `string` | `"restore"` | `"restore"`: save/restore IM per buffer around insert mode. `"fixed"`: always use default IM. |
-
-> [!TIP]
-> **Always Switch to Default IM (fixed mode)**
->
-> ```lua
-> require("im-switch").setup({
->   mode = "fixed",
-> })
-> ```
-
-### 🖥️ Platform options
-
-#### 🪟 Windows/WSL2
-
-The plugin is always enabled on Windows/WSL2. No configuration is needed.
-
-#### 🍎 macOS (`macos`)
-
-Add the `macos` table to enable the plugin on macOS.
-
-| Key | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `macos.default_im` | `string` | — | IM to set on InsertLeave (e.g., `"com.apple.keylayout.ABC"`) |
-
-#### 🐧 Linux (`linux`)
-
-Add the `linux` table to enable the plugin on Linux.
-
-| Key | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `linux.default_im` | `string` | — | IM to set on InsertLeave (framework-specific value) |
-| `linux.get_im_command` | `string[]?` | — | Custom command to get current IM _(only needed for IM frameworks not supported by the CLI)_ |
-| `linux.set_im_command` | `string[]?` | — | Custom command to set IM _(only needed for IM frameworks not supported by the CLI)_ |
-
-On Linux, the plugin resolves IM switching in this order:
-
-1. **Custom commands** — If `get_im_command`/`set_im_command` are configured, they are always used
-2. **[`im-switch`](https://github.com/drop-stones/im-switch) CLI** — If no custom commands are configured, the installed CLI is used (supports [fcitx5](https://github.com/fcitx/fcitx5) and [ibus](https://github.com/ibus/ibus))
-
-> [!TIP]
-> **Example: Linux with [fcitx5](https://github.com/fcitx/fcitx5) or [ibus](https://github.com/ibus/ibus) (using im-switch CLI)**
->
-> ```lua
-> require("im-switch").setup({
->   linux = {
->     default_im = "keyboard-us",
->   },
-> })
-> ```
-
-> [!TIP]
-> **Example: Linux with custom commands (for other IM frameworks)**
->
-> If you use an IM framework not supported by the `im-switch` CLI, you can specify custom commands:
->
-> ```lua
-> require("im-switch").setup({
->   linux = {
->     default_im = "default",
->     get_im_command = { "my-im-tool", "get" },
->     set_im_command = { "my-im-tool", "set" },
->   },
-> })
-> ```
 
 ## 🩺 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -67,49 +67,42 @@ The CLI binary is automatically downloaded from [GitHub Releases](https://github
 
 ## ⚙️  Configuration
 
-The plugin is activated per-platform by adding the corresponding settings table.
-
 ### 🔧 General options
 
-| Key                  | Type     | Default | Description |
-| -------------------- | -------- | ------- | ----------- |
-| `default_im_events`    | `string[]` | `{ "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" }` | Events that set the **default IM** |
-| `save_im_state_events` | `string[]` | `{ "InsertLeavePre" }` | Events that **save** the current IM |
-| `restore_im_events`    | `string[]` | `{ "InsertEnter" }` | Events that **restore** the saved IM |
+| Key    | Type     | Default     | Description |
+| ------ | -------- | ----------- | ----------- |
+| `mode` | `string` | `"restore"` | `"restore"`: save/restore IM per buffer around insert mode. `"fixed"`: always use default IM. |
 
 > [!TIP]
-> **Always Switch to Default IM on Mode Change (disable save/restore)**
+> **Always Switch to Default IM (fixed mode)**
 >
 > ```lua
 > require("im-switch").setup({
->  save_im_state_events = {},
->  restore_im_events = {},
+>   mode = "fixed",
 > })
 > ```
 
-### 🖥️ OS options
+### 🖥️ Platform options
 
-#### 🪟 Windows/WSL2 (`windows`)
+#### 🪟 Windows/WSL2
 
-Add the `windows` table to enable the plugin on Windows/WSL2. No additional options are needed.
-
-```lua
-require("im-switch").setup({
-  windows = {},
-})
-```
+The plugin is always enabled on Windows/WSL2. No configuration is needed.
 
 #### 🍎 macOS (`macos`)
 
+Add the `macos` table to enable the plugin on macOS.
+
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `macos.default_im` | `string` | — | IM to set when `default_im_events` triggers (e.g., `"com.apple.keylayout.ABC"`) |
+| `macos.default_im` | `string` | — | IM to set on InsertLeave (e.g., `"com.apple.keylayout.ABC"`) |
 
 #### 🐧 Linux (`linux`)
 
+Add the `linux` table to enable the plugin on Linux.
+
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `linux.default_im` | `string` | — | IM to set when `default_im_events` triggers (framework-specific value) |
+| `linux.default_im` | `string` | — | IM to set on InsertLeave (framework-specific value) |
 | `linux.get_im_command` | `string[]?` | — | Custom command to get current IM _(only needed for IM frameworks not supported by the CLI)_ |
 | `linux.set_im_command` | `string[]?` | — | Custom command to set IM _(only needed for IM frameworks not supported by the CLI)_ |
 

--- a/lua/im-switch/health.lua
+++ b/lua/im-switch/health.lua
@@ -29,6 +29,25 @@ local function check_platform()
   platform.check_health(opts)
 end
 
+---Check for deprecated config options.
+local function check_deprecated_options()
+  local opts = options.get()
+  local deprecated = { "default_im_events", "save_im_state_events", "restore_im_events" }
+  local found = false
+  for _, key in ipairs(deprecated) do
+    if opts[key] ~= nil then
+      vim.health.warn(
+        "'" .. key .. "' is deprecated",
+        { "Event options have been removed. Use 'mode = \"restore\"' (default) or 'mode = \"fixed\"' instead." }
+      )
+      found = true
+    end
+  end
+  if not found then
+    vim.health.ok("No deprecated options found")
+  end
+end
+
 ---Check for stale artifacts from older versions.
 local function check_migration()
   local old_bin_dir = utils.path.get_plugin_path("bin")
@@ -49,6 +68,7 @@ return {
     check_platform()
 
     vim.health.start("im-switch.nvim: migration")
+    check_deprecated_options()
     check_migration()
   end,
 }

--- a/lua/im-switch/im.lua
+++ b/lua/im-switch/im.lua
@@ -2,9 +2,6 @@ local im_command = require("im-switch.utils.im_command")
 local notify = require("im-switch.utils.notify")
 local system = require("im-switch.utils.system")
 
----@type string?
-local last_im_state = nil
-
 local M = {}
 
 ---Set the default input method for the current OS.
@@ -40,20 +37,20 @@ function M.save_im_state()
     return false
   end
 
-  -- Save the current IM state to options for later restoration
-  last_im_state = vim.trim(result.stdout)
+  -- Save the current IM state per buffer for later restoration
+  vim.b.im_switch_last_state = vim.trim(result.stdout)
   return true
 end
 
 ---Restore the previously saved input method state.
 ---@return boolean
 function M.restore_im()
-  -- If no previous state, get current IM and save it
-  if not last_im_state then
+  -- If no previous state for this buffer, get current IM and save it
+  if not vim.b.im_switch_last_state then
     M.save_im_state()
   end
 
-  local command, err = im_command.get_im_command("set", last_im_state)
+  local command, err = im_command.get_im_command("set", vim.b.im_switch_last_state)
   if err then
     notify.error(err)
     return false

--- a/lua/im-switch/im.lua
+++ b/lua/im-switch/im.lua
@@ -47,7 +47,9 @@ end
 function M.restore_im()
   -- If no previous state for this buffer, get current IM and save it
   if not vim.b.im_switch_last_state then
-    M.save_im_state()
+    if not M.save_im_state() then
+      return false
+    end
   end
 
   local command, err = im_command.get_im_command("set", vim.b.im_switch_last_state)

--- a/lua/im-switch/init.lua
+++ b/lua/im-switch/init.lua
@@ -22,31 +22,26 @@ function M.setup(user_opts)
   -- Create an autocommand group to manage the events
   local group_id = vim.api.nvim_create_augroup("im-switch", { clear = true })
 
-  -- Set up autocommand to set the default input method when `default_im_events` is triggered
-  if #opts.default_im_events > 0 then
-    vim.api.nvim_create_autocmd(opts.default_im_events, {
-      callback = function()
-        im.set_default_im()
-      end,
-      group = group_id,
-    })
-  end
+  -- Always set default IM on these events
+  vim.api.nvim_create_autocmd({ "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" }, {
+    callback = function()
+      im.set_default_im()
+    end,
+    group = group_id,
+  })
 
-  -- Set up autocommand to restore the previous input method when `restore_im_events` is triggered
-  if #opts.restore_im_events > 0 then
-    vim.api.nvim_create_autocmd(opts.restore_im_events, {
-      callback = function()
-        im.restore_im()
-      end,
-      group = group_id,
-    })
-  end
-
-  -- Set up autocommand to save the current input method when `save_im_state_events` is triggered
-  if #opts.save_im_state_events > 0 then
-    vim.api.nvim_create_autocmd(opts.save_im_state_events, {
+  -- In restore mode, save/restore IM state around insert mode
+  if opts.mode == "restore" then
+    vim.api.nvim_create_autocmd("InsertLeavePre", {
       callback = function()
         im.save_im_state()
+      end,
+      group = group_id,
+    })
+
+    vim.api.nvim_create_autocmd("InsertEnter", {
+      callback = function()
+        im.restore_im()
       end,
       group = group_id,
     })

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -33,6 +33,12 @@ function M.validate_options(opts)
     return false
   end
 
+  local valid_modes = { restore = true, fixed = true }
+  if opts.mode ~= nil and not valid_modes[opts.mode] then
+    require("im-switch.utils.notify").error("Invalid mode: '" .. tostring(opts.mode) .. "' (expected 'restore' or 'fixed')")
+    return false
+  end
+
   local platform = platforms.get_platform()
   if not platform then
     return true

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -3,14 +3,7 @@ local platforms = require("im-switch.platforms")
 --- Default plugin options
 ---@type PluginOptions
 local default_opts = {
-  -- Events that set the default input method.
-  default_im_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-
-  -- Events that save the current input method state.
-  save_im_state_events = { "InsertLeavePre" },
-
-  -- Events that restore the previously saved input method.
-  restore_im_events = { "InsertEnter" },
+  mode = "restore",
 }
 
 local M = {}
@@ -56,6 +49,11 @@ function M.is_plugin_enabled(opts)
   if not platform then
     return false
   end
+  -- Windows/WSL: always enabled (no user config needed)
+  if platform.opts_key == "windows" then
+    return true
+  end
+  -- macOS/Linux: enabled when platform table is present
   return opts[platform.opts_key] ~= nil
 end
 

--- a/lua/im-switch/platforms/windows.lua
+++ b/lua/im-switch/platforms/windows.lua
@@ -37,11 +37,7 @@ end
 
 ---@param opts table
 function M.check_health(opts)
-  if not opts.windows then
-    vim.health.warn("Windows/WSL plugin is not configured")
-    return
-  end
-  vim.health.ok("Windows/WSL plugin is enabled")
+  vim.health.ok("Windows/WSL plugin is enabled (always enabled on this platform)")
 
   local cli_path = path.get_cli_path()
   if vim.fn.executable(cli_path) == 1 then

--- a/lua/im-switch/types.lua
+++ b/lua/im-switch/types.lua
@@ -1,6 +1,3 @@
---- Windows settings (presence of this table enables the plugin on Windows/WSL2)
----@class WindowsSettings
-
 --- macOS settings
 ---@class MacosSettings
 ---@field default_im string
@@ -13,9 +10,6 @@
 
 --- Plugin options
 ---@class PluginOptions
----@field default_im_events string[] Events to set default input method
----@field save_im_state_events string[]  Events to save IM state
----@field restore_im_events string[] Events to restore IM state
----@field windows? WindowsSettings
+---@field mode? "restore"|"fixed" IM switching mode (default: "restore")
 ---@field macos? MacosSettings
 ---@field linux? LinuxSettings

--- a/tests/im_spec.lua
+++ b/tests/im_spec.lua
@@ -9,6 +9,7 @@ describe("im-switch.im", function()
   before_each(function()
     original_get_im_command = im_command.get_im_command
     original_vim_system = vim.system
+    vim.b.im_switch_last_state = nil
     ---@diagnostic disable-next-line: duplicate-set-field
     vim.system = function(_, _)
       return {

--- a/tests/im_spec.lua
+++ b/tests/im_spec.lua
@@ -69,5 +69,58 @@ describe("im-switch.im", function()
       assert.equals(calls[2].action, "set")
       assert.equals(calls[2].im_value, "dummy")
     end)
+
+    it("returns false when save_im_state fails", function()
+      ---@diagnostic disable-next-line: duplicate-set-field
+      im_command.get_im_command = function(action, _)
+        if action == "get" then
+          return nil, "command not found"
+        end
+        return { "echo", "set-im" }, nil
+      end
+      options.setup({ macos = { default_im = "dummy" } })
+      local ok = im.restore_im()
+      assert.is_false(ok)
+    end)
+  end)
+
+  describe("save_im_state (per-buffer)", function()
+    it("stores IM state independently per buffer", function()
+      ---@diagnostic disable-next-line: duplicate-set-field
+      im_command.get_im_command = function(action, im_value)
+        if action == "get" then
+          return { "echo", "get-im" }, nil
+        elseif action == "set" then
+          return { "echo", "set-im", im_value }, nil
+        end
+      end
+      options.setup({ macos = { default_im = "dummy" } })
+
+      -- Save state in buffer 1
+      local buf1 = vim.api.nvim_get_current_buf()
+      ---@diagnostic disable-next-line: duplicate-set-field
+      vim.system = function(_, _)
+        return { wait = function() return { code = 0, stdout = "im-jp\n", stderr = "" } end }
+      end
+      im.save_im_state()
+      assert.equals("im-jp", vim.b[buf1].im_switch_last_state)
+
+      -- Create buffer 2 and save different state
+      local buf2 = vim.api.nvim_create_buf(true, false)
+      vim.api.nvim_set_current_buf(buf2)
+      ---@diagnostic disable-next-line: duplicate-set-field
+      vim.system = function(_, _)
+        return { wait = function() return { code = 0, stdout = "im-en\n", stderr = "" } end }
+      end
+      im.save_im_state()
+      assert.equals("im-en", vim.b[buf2].im_switch_last_state)
+
+      -- Verify buffer 1 still has its own state
+      assert.equals("im-jp", vim.b[buf1].im_switch_last_state)
+
+      -- Cleanup
+      vim.api.nvim_set_current_buf(buf1)
+      vim.api.nvim_buf_delete(buf2, { force = true })
+    end)
   end)
 end)

--- a/tests/options_spec.lua
+++ b/tests/options_spec.lua
@@ -46,15 +46,9 @@ describe("im-switch.options", function()
         opts = {},
         expected = true,
       },
-      -- Windows
+      -- Windows (always valid, no config needed)
       {
-        desc = "Windows: valid config (empty table)",
-        os_type = "windows",
-        opts = { windows = {} },
-        expected = true,
-      },
-      {
-        desc = "Windows: no windows table",
+        desc = "Windows: no config",
         os_type = "windows",
         opts = {},
         expected = true,
@@ -119,9 +113,9 @@ describe("im-switch.options", function()
         expected = false,
       },
       {
-        desc = "enabled for windows with empty table",
+        desc = "always enabled for windows (no config needed)",
         os_type = "windows",
-        opts = { windows = {} },
+        opts = {},
         expected = true,
       },
       {
@@ -148,15 +142,13 @@ describe("im-switch.options", function()
       options.setup({ macos = { default_im = "com.apple.keylayout.ABC" } })
       local opts = options.get()
       assert.equals("com.apple.keylayout.ABC", opts.macos.default_im)
-      -- Default event options should be preserved
-      assert.is_truthy(opts.default_im_events)
-      assert.is_true(#opts.default_im_events > 0)
+      assert.equals("restore", opts.mode)
     end)
 
-    it("allows overriding default events", function()
-      options.setup({ default_im_events = { "VimEnter" } })
+    it("allows setting fixed mode", function()
+      options.setup({ mode = "fixed" })
       local opts = options.get()
-      assert.are.same({ "VimEnter" }, opts.default_im_events)
+      assert.equals("fixed", opts.mode)
     end)
   end)
 end)

--- a/tests/options_spec.lua
+++ b/tests/options_spec.lua
@@ -78,6 +78,25 @@ describe("im-switch.options", function()
         opts = {},
         expected = true,
       },
+      -- Invalid mode
+      {
+        desc = "invalid mode",
+        os_type = "macos",
+        opts = { mode = "typo" },
+        expected = false,
+      },
+      {
+        desc = "valid mode: fixed",
+        os_type = "macos",
+        opts = { mode = "fixed" },
+        expected = true,
+      },
+      {
+        desc = "valid mode: restore",
+        os_type = "macos",
+        opts = { mode = "restore" },
+        expected = true,
+      },
       -- Non-table input
       {
         desc = "non-table input",


### PR DESCRIPTION
## Summary
- Replace `default_im_events`/`save_im_state_events`/`restore_im_events` with `mode = "restore" | "fixed"`
- Remove `windows` config: always enabled on Windows/WSL (no setup needed)
- Store IM state per buffer (restore mode now remembers IM per buffer)
- Add checkhealth warning for deprecated event options
- Update README

## Breaking changes
- Event options (`default_im_events`, `save_im_state_events`, `restore_im_events`) removed
  - Use `mode = "fixed"` instead of emptying event lists
  - `mode = "restore"` (default) keeps the previous behavior
- `windows = {}` no longer needed (plugin auto-enables on Windows/WSL)

## Test plan
- [x] All 59 unit tests pass
- [x] CI unittest passes
- [x] CI integration test passes on all 3 platforms
- [x] checkhealth warns on deprecated event options

🤖 Generated with [Claude Code](https://claude.com/claude-code)