### PR TITLE
feat(wsl2): add the loopback IPC fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,37 @@ require("im-switch").setup({
 > }
 > ```
 
+### WSL2
+
+| Key | Type | Required | Description |
+| --- | ---- | -------- | ----------- |
+| `wsl2.server` | `boolean` | No | Opt into the loopback IPC fast path (default: `false`) |
+
+On WSL the plugin controls the **Windows** IME with no configuration required.
+By default each switch runs `im-switch.exe` through WSL interop, which adds about 60 ms of process-startup latency.
+Set `wsl2.server = true` to enable the **loopback IPC fast path**: a long-lived Windows daemon is started once and each
+switch is forwarded to it over TCP (about 1–2 ms instead of 60 ms), with a transparent fallback to a direct call if the daemon is unreachable.
+
+```lua
+require("im-switch").setup({
+  wsl2 = {
+    server = true,
+  },
+})
+```
+
+> [!NOTE]
+> The fast path requires **WSL2 mirrored networking mode** (Windows 11 22H2+),
+> enabled in `C:\Users\<user>\.wslconfig` (run `wsl --shutdown` after editing):
+>
+> ```ini
+> [wsl2]
+> networkingMode=mirrored
+>
+> [experimental]
+> hostAddressLoopback=true
+> ```
+
 ## 🔄 How it switches IM
 
 Neovim cannot switch IM directly, so this plugin uses the [`im-switch`](https://github.com/drop-stones/im-switch) CLI:

--- a/lua/im-switch/build.lua
+++ b/lua/im-switch/build.lua
@@ -3,9 +3,9 @@ local path = require("im-switch.utils.path")
 local platforms = require("im-switch.platforms")
 local system = require("im-switch.utils.system")
 
-local RELEASE_TAG = "v0.1.1"
+local RELEASE_TAG = "v0.2.0"
 local DOWNLOAD_URL = "https://github.com/drop-stones/im-switch/releases/download/" .. RELEASE_TAG .. "/im-switch-%s.tar.gz"
-local REQUIRED_VERSION = { 0, 1, 1 }
+local REQUIRED_VERSION = { 0, 2, 0 }
 
 local M = {}
 
@@ -37,6 +37,19 @@ function M.get_target_triple()
   return platform.target_triple(cpu)
 end
 
+---Resolve the install plan: the list of `{ triple, path }` binaries to install.
+---Platforms may override with `download_plan` (WSL2 installs two binaries);
+---otherwise a single binary at the platform's CLI path.
+---@param platform table
+---@param cpu string
+---@return table[]
+local function get_download_plan(platform, cpu)
+  if platform.download_plan then
+    return platform.download_plan(cpu)
+  end
+  return { { triple = platform.target_triple(cpu), path = path.get_cli_path() } }
+end
+
 ---Parse a semantic version string (e.g., "im-switch 0.1.0") into a table.
 ---@param version_str string
 ---@return number[]?
@@ -66,12 +79,24 @@ end
 ---Check if the installed CLI meets the required version.
 ---@return boolean
 function M.is_version_satisfied()
-  local cli_path = path.get_cli_path()
-  if vim.fn.executable(cli_path) ~= 1 then
+  local platform = platforms.get_platform()
+  if not platform then
+    return false
+  end
+  local cpu = get_cpu()
+  if not cpu then
     return false
   end
 
-  local result = system.run_system({ cli_path, "--version" })
+  -- Every planned binary must be present (WSL2 needs both client and server).
+  for _, item in ipairs(get_download_plan(platform, cpu)) do
+    if vim.fn.executable(item.path) ~= 1 then
+      return false
+    end
+  end
+
+  -- ...and the primary binary must meet the required version.
+  local result = system.run_system({ path.get_cli_path(), "--version" })
   if result.code ~= 0 then
     return false
   end
@@ -96,15 +121,13 @@ function M.setup()
     return
   end
 
-  local target, err = M.get_target_triple()
-  if err then
-    notify.error("Failed to detect target: " .. err)
+  local cpu, cpu_err = get_cpu()
+  if cpu_err then
+    notify.error("Failed to detect architecture: " .. cpu_err)
     return
   end
 
   local install_dir = path.get_install_dir()
-  local cli_path = path.get_cli_path()
-  local url = string.format(DOWNLOAD_URL, target)
   local archive_path = vim.fs.joinpath(install_dir, "im-switch.tar.gz")
 
   -- Preflight check for required tools
@@ -118,28 +141,30 @@ function M.setup()
   -- Create install directory
   vim.fn.mkdir(install_dir, "p")
 
-  -- Download
-  notify.info("Downloading im-switch CLI from " .. url)
-  local result = system.run_system({ "curl", "-fSL", "-o", archive_path, url })
-  if result.code ~= 0 then
-    notify.error("Failed to download im-switch CLI: " .. result.stderr)
-    return
-  end
+  -- Download and install each planned binary (WSL2 installs two).
+  for _, item in ipairs(get_download_plan(platform, cpu)) do
+    local url = string.format(DOWNLOAD_URL, item.triple)
+    notify.info("Downloading im-switch CLI from " .. url)
+    local result = system.run_system({ "curl", "-fSL", "-o", archive_path, url })
+    if result.code ~= 0 then
+      notify.error("Failed to download im-switch CLI: " .. result.stderr)
+      return
+    end
 
-  -- Extract
-  result = system.run_system({ "tar", "xzf", archive_path, "-C", install_dir })
-  if result.code ~= 0 then
-    notify.error("Failed to extract im-switch CLI: " .. result.stderr)
-    return
-  end
+    result = system.run_system({ "tar", "xzf", archive_path, "-C", install_dir })
+    if result.code ~= 0 then
+      notify.error("Failed to extract im-switch CLI: " .. result.stderr)
+      return
+    end
 
-  -- Platform-specific post-install (e.g., chmod +x on Unix)
-  platform.post_install(cli_path)
+    -- Platform-specific post-install (e.g., chmod +x on Unix)
+    platform.post_install(item.path)
+  end
 
   -- Clean up archive
   os.remove(archive_path)
 
-  notify.info("Successfully installed im-switch CLI to " .. cli_path)
+  notify.info("Successfully installed im-switch CLI to " .. install_dir)
 end
 
 return M

--- a/lua/im-switch/build.lua
+++ b/lua/im-switch/build.lua
@@ -4,7 +4,9 @@ local platforms = require("im-switch.platforms")
 local system = require("im-switch.utils.system")
 
 local RELEASE_TAG = "v0.2.0"
-local DOWNLOAD_URL = "https://github.com/drop-stones/im-switch/releases/download/" .. RELEASE_TAG .. "/im-switch-%s.tar.gz"
+local DOWNLOAD_URL = "https://github.com/drop-stones/im-switch/releases/download/"
+  .. RELEASE_TAG
+  .. "/im-switch-%s.tar.gz"
 local REQUIRED_VERSION = { 0, 2, 0 }
 
 local M = {}

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -41,15 +41,18 @@ function M.validate_options(opts)
     return false
   end
 
-  if opts.wsl2 ~= nil then
-    if type(opts.wsl2) ~= "table" then
-      require("im-switch.utils.notify").error("'wsl2' must be a table")
+  -- Platform settings, when present, must be tables. (Guard before
+  -- platform.validate, which indexes these and would otherwise throw on a
+  -- non-table value such as a number or boolean.)
+  for _, key in ipairs({ "macos", "linux", "wsl2" }) do
+    if opts[key] ~= nil and type(opts[key]) ~= "table" then
+      require("im-switch.utils.notify").error("'" .. key .. "' must be a table")
       return false
     end
-    if opts.wsl2.server ~= nil and type(opts.wsl2.server) ~= "boolean" then
-      require("im-switch.utils.notify").error("'wsl2.server' must be a boolean")
-      return false
-    end
+  end
+  if opts.wsl2 ~= nil and opts.wsl2.server ~= nil and type(opts.wsl2.server) ~= "boolean" then
+    require("im-switch.utils.notify").error("'wsl2.server' must be a boolean")
+    return false
   end
 
   local platform = platforms.get_platform()

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -39,6 +39,17 @@ function M.validate_options(opts)
     return false
   end
 
+  if opts.wsl2 ~= nil then
+    if type(opts.wsl2) ~= "table" then
+      require("im-switch.utils.notify").error("'wsl2' must be a table")
+      return false
+    end
+    if opts.wsl2.server ~= nil and type(opts.wsl2.server) ~= "boolean" then
+      require("im-switch.utils.notify").error("'wsl2.server' must be a boolean")
+      return false
+    end
+  end
+
   local platform = platforms.get_platform()
   if not platform then
     return true
@@ -55,11 +66,11 @@ function M.is_plugin_enabled(opts)
   if not platform then
     return false
   end
-  -- Windows/WSL: always enabled (no user config needed)
-  if platform.opts_key == "windows" then
+  -- Platforms with no required config (Windows/WSL2) are always enabled.
+  if platform.always_enabled then
     return true
   end
-  -- macOS/Linux: enabled when platform table is present
+  -- macOS/Linux: enabled when their settings table is present.
   return opts[platform.opts_key] ~= nil
 end
 

--- a/lua/im-switch/options.lua
+++ b/lua/im-switch/options.lua
@@ -35,7 +35,9 @@ function M.validate_options(opts)
 
   local valid_modes = { restore = true, fixed = true }
   if opts.mode ~= nil and not valid_modes[opts.mode] then
-    require("im-switch.utils.notify").error("Invalid mode: '" .. tostring(opts.mode) .. "' (expected 'restore' or 'fixed')")
+    require("im-switch.utils.notify").error(
+      "Invalid mode: '" .. tostring(opts.mode) .. "' (expected 'restore' or 'fixed')"
+    )
     return false
   end
 

--- a/lua/im-switch/platforms/init.lua
+++ b/lua/im-switch/platforms/init.lua
@@ -10,8 +10,10 @@ function M.get_platform()
     return nil, err
   end
 
-  if os_type == "windows" or os_type == "wsl" then
+  if os_type == "windows" then
     return require("im-switch.platforms.windows")
+  elseif os_type == "wsl" then
+    return require("im-switch.platforms.wsl2")
   elseif os_type == "macos" then
     return require("im-switch.platforms.macos")
   elseif os_type == "linux" then

--- a/lua/im-switch/platforms/macos.lua
+++ b/lua/im-switch/platforms/macos.lua
@@ -54,7 +54,9 @@ function M.check_health(opts)
   if vim.fn.executable(cli_path) == 1 then
     vim.health.ok("im-switch CLI is installed at " .. cli_path)
   else
-    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)")
+    vim.health.error(
+      "im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)"
+    )
   end
 end
 

--- a/lua/im-switch/platforms/windows.lua
+++ b/lua/im-switch/platforms/windows.lua
@@ -48,7 +48,9 @@ function M.check_health(opts)
   if vim.fn.executable(cli_path) == 1 then
     vim.health.ok("im-switch CLI is installed at " .. cli_path)
   else
-    vim.health.error("im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)")
+    vim.health.error(
+      "im-switch CLI is not installed at " .. cli_path .. " (rebuild or reinstall the plugin with your plugin manager)"
+    )
   end
 end
 

--- a/lua/im-switch/platforms/windows.lua
+++ b/lua/im-switch/platforms/windows.lua
@@ -3,6 +3,9 @@ local path = require("im-switch.utils.path")
 local M = {}
 
 M.opts_key = "windows"
+-- Windows/WSL control the IME with no required config, so the plugin is always
+-- enabled on these platforms (see options.is_plugin_enabled).
+M.always_enabled = true
 
 ---@param action "get"|"set"
 ---@param im_value? string

--- a/lua/im-switch/platforms/wsl2.lua
+++ b/lua/im-switch/platforms/wsl2.lua
@@ -1,0 +1,78 @@
+local path = require("im-switch.utils.path")
+local windows = require("im-switch.platforms.windows")
+local linux = require("im-switch.platforms.linux")
+
+-- WSL2 inherits the Windows IME behavior and adds an opt-in loopback IPC fast
+-- path. Anything not overridden here falls through to the Windows platform.
+local M = setmetatable({}, { __index = windows })
+
+M.opts_key = "wsl2"
+M.always_enabled = true
+
+---@param opts table
+---@return boolean
+local function fast_path_enabled(opts)
+  return opts.wsl2 ~= nil and opts.wsl2.server == true
+end
+
+---@param action "get"|"set"
+---@param im_value? string
+---@param opts table
+---@return string[]?, string?
+function M.get_im_command(action, im_value, opts)
+  -- Without the opt-in, behave exactly like Windows (run im-switch.exe directly).
+  if not fast_path_enabled(opts) then
+    return windows.get_im_command(action, im_value, opts)
+  end
+
+  -- Resolve the `ime` argument.
+  local arg
+  if action == "get" then
+    arg = "get"
+  elseif action == "set" then
+    if im_value ~= "on" and im_value ~= "off" then
+      return nil, "Unknown IME state: " .. tostring(im_value) .. " (expected 'on' or 'off')"
+    end
+    arg = im_value
+  else
+    return nil, "Unsupported action for WSL2: " .. tostring(action)
+  end
+
+  -- Forward to the loopback daemon via the Linux client. On transport failure
+  -- (exit 2 = daemon unreachable) run the Windows server directly and (re)start
+  -- the daemon. Self-contained so the generic runner needs no special-casing.
+  local client = path.get_wsl2_client_path()
+  local server = path.get_wsl2_server_path()
+  local script = string.format(
+    "'%s' remote ime %s; rc=$?; [ \"$rc\" = 2 ] && { setsid '%s' serve >/dev/null 2>&1 </dev/null & exec '%s' ime %s; }; exit $rc",
+    client,
+    arg,
+    server,
+    server,
+    arg
+  )
+  return { "sh", "-c", script }
+end
+
+---Binaries to install on WSL2: the native Linux client and the Windows server,
+---both into the WSL install dir. (Installed regardless of the fast-path opt-in,
+---since the build step runs without access to user options.)
+---@param cpu string
+---@return table[]
+function M.download_plan(cpu)
+  return {
+    { triple = linux.target_triple(cpu), path = path.get_wsl2_client_path() },
+    { triple = windows.target_triple(cpu), path = path.get_wsl2_server_path() },
+  }
+end
+
+---@param cli_path string
+function M.post_install(cli_path)
+  local system = require("im-switch.utils.system")
+  local result = system.run_system({ "chmod", "+x", cli_path })
+  if result.code ~= 0 then
+    require("im-switch.utils.notify").error("Failed to set executable permissions: " .. result.stderr)
+  end
+end
+
+return M

--- a/lua/im-switch/platforms/wsl2.lua
+++ b/lua/im-switch/platforms/wsl2.lua
@@ -1,6 +1,6 @@
+local linux = require("im-switch.platforms.linux")
 local path = require("im-switch.utils.path")
 local windows = require("im-switch.platforms.windows")
-local linux = require("im-switch.platforms.linux")
 
 -- WSL2 inherits the Windows IME behavior and adds an opt-in loopback IPC fast
 -- path. Anything not overridden here falls through to the Windows platform.

--- a/lua/im-switch/platforms/wsl2.lua
+++ b/lua/im-switch/platforms/wsl2.lua
@@ -9,6 +9,15 @@ local M = setmetatable({}, { __index = windows })
 M.opts_key = "wsl2"
 M.always_enabled = true
 
+---Escape a string for safe embedding inside single quotes in a shell command.
+---A literal `'` (a valid character in Unix paths) is rewritten as `'\''`, which
+---closes the quote, inserts an escaped quote, then reopens it.
+---@param s string
+---@return string
+local function sh_quote(s)
+  return (s:gsub("'", "'\\''"))
+end
+
 ---@param opts table
 ---@return boolean
 local function fast_path_enabled(opts)
@@ -41,8 +50,8 @@ function M.get_im_command(action, im_value, opts)
   -- Forward to the loopback daemon via the Linux client. On transport failure
   -- (exit 2 = daemon unreachable) run the Windows server directly and (re)start
   -- the daemon. Self-contained so the generic runner needs no special-casing.
-  local client = path.get_wsl2_client_path()
-  local server = path.get_wsl2_server_path()
+  local client = sh_quote(path.get_wsl2_client_path())
+  local server = sh_quote(path.get_wsl2_server_path())
   local script = string.format(
     "'%s' remote ime %s; rc=$?; [ \"$rc\" = 2 ] && { setsid '%s' serve >/dev/null 2>&1 </dev/null & exec '%s' ime %s; }; exit $rc",
     client,

--- a/lua/im-switch/types.lua
+++ b/lua/im-switch/types.lua
@@ -8,8 +8,13 @@
 ---@field get_im_command? string[]
 ---@field set_im_command? string[]
 
+--- WSL2 settings
+---@class Wsl2Settings
+---@field server? boolean Opt into the loopback IPC fast path (default: false)
+
 --- Plugin options
 ---@class PluginOptions
 ---@field mode? "restore"|"fixed" IM switching mode (default: "restore")
 ---@field macos? MacosSettings
 ---@field linux? LinuxSettings
+---@field wsl2? Wsl2Settings

--- a/lua/im-switch/utils/path.lua
+++ b/lua/im-switch/utils/path.lua
@@ -18,7 +18,9 @@ local function get_plugin_root_path()
   if result.code ~= 0 then
     -- Fallback: this file is at lua/im-switch/utils/path.lua, so root is 3 levels up
     local fallback = vim.fn.fnamemodify(this_dir, ":h:h:h")
-    notify.warn("Failed to detect plugin root (git rev-parse failed in " .. this_dir .. "), using fallback: " .. fallback)
+    notify.warn(
+      "Failed to detect plugin root (git rev-parse failed in " .. this_dir .. "), using fallback: " .. fallback
+    )
     cached_plugin_root_path = fallback
     return cached_plugin_root_path
   end

--- a/lua/im-switch/utils/path.lua
+++ b/lua/im-switch/utils/path.lua
@@ -66,4 +66,16 @@ function M.get_cli_path()
   return vim.fs.joinpath(dir, "im-switch")
 end
 
+---Get the path to the native Linux client used by the WSL2 fast path.
+---@return string
+function M.get_wsl2_client_path()
+  return vim.fs.joinpath(M.get_install_dir(), "im-switch")
+end
+
+---Get the path to the Windows server used by the WSL2 fast path.
+---@return string
+function M.get_wsl2_server_path()
+  return vim.fs.joinpath(M.get_install_dir(), "im-switch.exe")
+end
+
 return M

--- a/tests/im_command_spec.lua
+++ b/tests/im_command_spec.lua
@@ -182,7 +182,11 @@ describe("im-switch.utils.im_command.get_im_command (table-driven)", function()
       cli_path = "/home/user/.local/share/im-switch.nvim/im-switch",
       cli_installed = true,
       opts = {
-        linux = { default_im = "keyboard-us", get_im_command = { "fcitx5-remote", "-n" }, set_im_command = { "fcitx5-remote", "-s" } },
+        linux = {
+          default_im = "keyboard-us",
+          get_im_command = { "fcitx5-remote", "-n" },
+          set_im_command = { "fcitx5-remote", "-s" },
+        },
         windows = {},
         macos = {},
       },
@@ -196,7 +200,11 @@ describe("im-switch.utils.im_command.get_im_command (table-driven)", function()
       cli_path = "/home/user/.local/share/im-switch.nvim/im-switch",
       cli_installed = true,
       opts = {
-        linux = { default_im = "keyboard-us", get_im_command = { "fcitx5-remote", "-n" }, set_im_command = { "fcitx5-remote", "-s" } },
+        linux = {
+          default_im = "keyboard-us",
+          get_im_command = { "fcitx5-remote", "-n" },
+          set_im_command = { "fcitx5-remote", "-s" },
+        },
         windows = {},
         macos = {},
       },

--- a/tests/im_spec.lua
+++ b/tests/im_spec.lua
@@ -100,7 +100,11 @@ describe("im-switch.im", function()
       local buf1 = vim.api.nvim_get_current_buf()
       ---@diagnostic disable-next-line: duplicate-set-field
       vim.system = function(_, _)
-        return { wait = function() return { code = 0, stdout = "im-jp\n", stderr = "" } end }
+        return {
+          wait = function()
+            return { code = 0, stdout = "im-jp\n", stderr = "" }
+          end,
+        }
       end
       im.save_im_state()
       assert.equals("im-jp", vim.b[buf1].im_switch_last_state)
@@ -110,7 +114,11 @@ describe("im-switch.im", function()
       vim.api.nvim_set_current_buf(buf2)
       ---@diagnostic disable-next-line: duplicate-set-field
       vim.system = function(_, _)
-        return { wait = function() return { code = 0, stdout = "im-en\n", stderr = "" } end }
+        return {
+          wait = function()
+            return { code = 0, stdout = "im-en\n", stderr = "" }
+          end,
+        }
       end
       im.save_im_state()
       assert.equals("im-en", vim.b[buf2].im_switch_last_state)

--- a/tests/options_spec.lua
+++ b/tests/options_spec.lua
@@ -3,9 +3,9 @@ options_spec.lua
 Unit tests for im-switch.options: validation, plugin activation, and setup.
 ]]
 
+local im_command = require("im-switch.utils.im_command")
 local options = require("im-switch.options")
 local os_utils = require("im-switch.utils.os")
-local im_command = require("im-switch.utils.im_command")
 
 describe("im-switch.options", function()
   local original_get_os_type

--- a/tests/options_spec.lua
+++ b/tests/options_spec.lua
@@ -78,6 +78,37 @@ describe("im-switch.options", function()
         opts = {},
         expected = true,
       },
+      -- WSL2 fast-path option
+      {
+        desc = "WSL2: server = true",
+        os_type = "wsl",
+        opts = { wsl2 = { server = true } },
+        expected = true,
+      },
+      {
+        desc = "WSL2: server = false",
+        os_type = "wsl",
+        opts = { wsl2 = { server = false } },
+        expected = true,
+      },
+      {
+        desc = "WSL2: no wsl2 table (always valid)",
+        os_type = "wsl",
+        opts = {},
+        expected = true,
+      },
+      {
+        desc = "WSL2: server is not a boolean",
+        os_type = "wsl",
+        opts = { wsl2 = { server = "yes" } },
+        expected = false,
+      },
+      {
+        desc = "WSL2: wsl2 is not a table",
+        os_type = "wsl",
+        opts = { wsl2 = "invalid" },
+        expected = false,
+      },
       -- Invalid mode
       {
         desc = "invalid mode",
@@ -134,6 +165,12 @@ describe("im-switch.options", function()
       {
         desc = "always enabled for windows (no config needed)",
         os_type = "windows",
+        opts = {},
+        expected = true,
+      },
+      {
+        desc = "always enabled for WSL (no config needed)",
+        os_type = "wsl",
         opts = {},
         expected = true,
       },

--- a/tests/options_spec.lua
+++ b/tests/options_spec.lua
@@ -46,6 +46,12 @@ describe("im-switch.options", function()
         opts = {},
         expected = true,
       },
+      {
+        desc = "macOS: macos is not a table (number)",
+        os_type = "macos",
+        opts = { macos = 123 },
+        expected = false,
+      },
       -- Windows (always valid, no config needed)
       {
         desc = "Windows: no config",
@@ -77,6 +83,12 @@ describe("im-switch.options", function()
         os_type = "linux",
         opts = {},
         expected = true,
+      },
+      {
+        desc = "Linux: linux is not a table (boolean)",
+        os_type = "linux",
+        opts = { linux = true },
+        expected = false,
       },
       -- WSL2 fast-path option
       {

--- a/tests/wsl2_spec.lua
+++ b/tests/wsl2_spec.lua
@@ -1,0 +1,102 @@
+--[[
+wsl2_spec.lua
+Unit tests for the WSL2 platform module: the fast-path command (with
+self-contained fallback), delegation to Windows when not opted in, the
+two-binary download plan, and platform routing.
+]]
+
+local wsl2 = require("im-switch.platforms.wsl2")
+local path = require("im-switch.utils.path")
+
+describe("im-switch.platforms.wsl2", function()
+  local orig = {}
+
+  before_each(function()
+    orig.get_cli_path = path.get_cli_path
+    orig.get_wsl2_client_path = path.get_wsl2_client_path
+    orig.get_wsl2_server_path = path.get_wsl2_server_path
+    ---@diagnostic disable: duplicate-set-field
+    path.get_cli_path = function()
+      return "/d/im-switch.exe"
+    end
+    path.get_wsl2_client_path = function()
+      return "/d/im-switch"
+    end
+    path.get_wsl2_server_path = function()
+      return "/d/im-switch.exe"
+    end
+    ---@diagnostic enable: duplicate-set-field
+  end)
+
+  after_each(function()
+    path.get_cli_path = orig.get_cli_path
+    path.get_wsl2_client_path = orig.get_wsl2_client_path
+    path.get_wsl2_server_path = orig.get_wsl2_server_path
+  end)
+
+  it("is always enabled", function()
+    assert.is_true(wsl2.always_enabled)
+    assert.equals("wsl2", wsl2.opts_key)
+  end)
+
+  describe("get_im_command without the opt-in (delegates to Windows)", function()
+    it("no wsl2 table -> direct .exe", function()
+      local cmd = wsl2.get_im_command("set", "off", {})
+      assert.are.same({ "/d/im-switch.exe", "ime", "off" }, cmd)
+    end)
+
+    it("wsl2.server = false -> direct .exe", function()
+      local cmd = wsl2.get_im_command("get", nil, { wsl2 = { server = false } })
+      assert.are.same({ "/d/im-switch.exe", "ime", "get" }, cmd)
+    end)
+  end)
+
+  describe("get_im_command with the fast path (wsl2.server = true)", function()
+    local opts = { wsl2 = { server = true } }
+
+    it("get -> remote with self-contained fallback", function()
+      local cmd = wsl2.get_im_command("get", nil, opts)
+      assert.equals("sh", cmd[1])
+      assert.equals("-c", cmd[2])
+      local s = cmd[3]
+      assert.is_true(s:find("'/d/im-switch' remote ime get", 1, true) ~= nil)
+      assert.is_true(s:find("setsid '/d/im-switch.exe' serve", 1, true) ~= nil)
+      assert.is_true(s:find("exec '/d/im-switch.exe' ime get", 1, true) ~= nil)
+    end)
+
+    it("set off -> remote with fallback", function()
+      local cmd = wsl2.get_im_command("set", "off", opts)
+      assert.is_true(cmd[3]:find("remote ime off", 1, true) ~= nil)
+      assert.is_true(cmd[3]:find("exec '/d/im-switch.exe' ime off", 1, true) ~= nil)
+    end)
+
+    it("set with an invalid value -> error", function()
+      local cmd, err = wsl2.get_im_command("set", "enabled", opts)
+      assert.is_nil(cmd)
+      assert.is_true(err:find("Unknown IME state", 1, true) ~= nil)
+    end)
+  end)
+
+  describe("download_plan", function()
+    it("installs the Linux client and the Windows server", function()
+      local plan = wsl2.download_plan("x86_64")
+      assert.equals(2, #plan)
+      assert.equals("x86_64-unknown-linux-musl", plan[1].triple)
+      assert.equals("/d/im-switch", plan[1].path)
+      assert.equals("x86_64-pc-windows-msvc", plan[2].triple)
+      assert.equals("/d/im-switch.exe", plan[2].path)
+    end)
+  end)
+
+  it("routes os_type 'wsl' to the wsl2 platform", function()
+    local os_utils = require("im-switch.utils.os")
+    local original = os_utils.get_os_type
+    ---@diagnostic disable-next-line: duplicate-set-field
+    os_utils.get_os_type = function()
+      return "wsl"
+    end
+    local platform = require("im-switch.platforms").get_platform()
+    os_utils.get_os_type = original
+    assert.equals("wsl2", platform.opts_key)
+  end)
+end)

--- a/tests/wsl2_spec.lua
+++ b/tests/wsl2_spec.lua
@@ -75,6 +75,22 @@ describe("im-switch.platforms.wsl2", function()
       assert.is_nil(cmd)
       assert.is_true(err:find("Unknown IME state", 1, true) ~= nil)
     end)
+
+    it("escapes single quotes in the install path", function()
+      ---@diagnostic disable: duplicate-set-field
+      path.get_wsl2_client_path = function()
+        return "/home/o'brien/im-switch"
+      end
+      path.get_wsl2_server_path = function()
+        return "/home/o'brien/im-switch.exe"
+      end
+      ---@diagnostic enable: duplicate-set-field
+      local cmd = wsl2.get_im_command("get", nil, opts)
+      local s = cmd[3]
+      -- The `'` is closed, escaped, then reopened: '\''
+      assert.is_true(s:find("'/home/o'\\''brien/im-switch' remote ime get", 1, true) ~= nil)
+      assert.is_true(s:find("exec '/home/o'\\''brien/im-switch.exe' ime get", 1, true) ~= nil)
+    end)
   end)
 
   describe("download_plan", function()

--- a/tests/wsl2_spec.lua
+++ b/tests/wsl2_spec.lua
@@ -5,8 +5,8 @@ self-contained fallback), delegation to Windows when not opted in, the
 two-binary download plan, and platform routing.
 ]]
 
-local wsl2 = require("im-switch.platforms.wsl2")
 local path = require("im-switch.utils.path")
+local wsl2 = require("im-switch.platforms.wsl2")
 
 describe("im-switch.platforms.wsl2", function()
   local orig = {}


### PR DESCRIPTION
## Summary

Adds an opt-in WSL2 fast path that avoids the ~60 ms per-switch cost of spawning `im-switch.exe` through WSL interop. When `wsl2.server = true`, IME switches are forwarded to a long-lived Windows daemon over loopback TCP (~1–2 ms), with a transparent fallback to a direct `.exe` call if the daemon is unreachable.

Requires the [`im-switch`](https://github.com/drop-stones/im-switch) CLI **0.2.0** (the `serve`/`remote` subcommands) and WSL2 mirrored networking mode.

## What changed

- **Config**: new `wsl2.server` option (default `false`); validated like the other platform tables. WSL is always enabled (`always_enabled`), no required config.
- **WSL2 platform module** (`platforms/wsl2.lua`): inherits the Windows behavior; on the fast path builds a self-contained `sh -c` command that forwards `im-switch remote ime …` and, on transport failure (exit 2 = daemon unreachable), runs the `.exe` directly and respawns the daemon. Without the opt-in it delegates to Windows (unchanged behavior).
- **Build**: targets `im-switch` 0.2.0 and installs both WSL2 binaries (the native Linux client and the Windows server) into the install dir.
- **Quote safety**: paths interpolated into the `sh -c` string are single-quote-escaped, so install dirs containing a `'` don't break the command.
- **Formatting**: a `style:` commit makes the repo stylua-clean (sort_requires + 120-column width); no behavior change.
- **Docs**: README documents the `wsl2.server` option and its requirements.

## Tests

- `bash scripts/test` — 81 cases, 0 fails. New `wsl2_spec.lua` covers the fast-path command, delegation, the two-binary download plan, platform routing, and single-quote escaping.
- Verified hands-on under WSL2 mirrored mode (`NVIM_APPNAME=nvim-config`): IME switches go through the resident daemon; fallback engages transparently when the daemon is down.

## Out of scope

- Plugin loading / initial-IM-set timing improvements are deferred to a separate PR.