### PR TITLE
refactor: drive IM switching solely by editing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ Install the plugin with your preferred package manager.
 ```lua
 {
   "drop-stones/im-switch.nvim",
-  event = "VeryLazy",
+  event = { "InsertEnter", "CmdlineEnter" },
   opts = {
     -- your configurations
   }
 }
 ```
+
+> [!NOTE]
+> The plugin only reacts to editing-mode transitions — `InsertLeave`/`CmdlineLeave` (and, in `restore`
+> mode, `InsertEnter`/`InsertLeavePre`) — so it is safe to load it as late as the first time you type.
+> Loading on `InsertEnter` and `CmdlineEnter` covers both insert and command-line input. You are free to
+> pick any other lazy-loading trigger that fits your workflow.
 
 ## ⚙️ Configuration
 

--- a/lua/im-switch/init.lua
+++ b/lua/im-switch/init.lua
@@ -23,7 +23,7 @@ function M.setup(user_opts)
   local group_id = vim.api.nvim_create_augroup("im-switch", { clear = true })
 
   -- Always set default IM on these events
-  vim.api.nvim_create_autocmd({ "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" }, {
+  vim.api.nvim_create_autocmd({ "InsertLeave", "CmdlineLeave" }, {
     callback = function()
       im.set_default_im()
     end,


### PR DESCRIPTION
## Summary

Makes the plugin react only to predictable editing events, removing two triggers that were either dead or counter-productive, and updates the recommended lazy-loading events accordingly.

## What changed

- **Drop `VimEnter`**: it is already dead under lazy-loading (it has fired before the plugin loads), which made the startup IM reset silently depend on load timing. Startup IM state is the OS's concern and self-heals on the first editing event; users who still want a startup reset can add their own autocmd.
- **Drop `FocusGained`**: only useful with a *global* IME manager; under per-window IME (common with fcitx5 "Share State: Program/No", Windows per-app IME, macOS per-app input sources) it is a redundant no-op, and it could force the IM off *mid-insert* when focus returns to Neovim. It also requires terminal focus-reporting to fire at all.
- Result — the always-on group is now just `InsertLeave` / `CmdlineLeave` (plus the restore-mode `InsertLeavePre` save / `InsertEnter` restore).
- **README**: recommend `event = { "InsertEnter", "CmdlineEnter" }` (covers insert and command-line input) and note any other lazy trigger works.

## Event model after this change

| Event | Mode | Action |
| --- | --- | --- |
| `InsertLeave` / `CmdlineLeave` | both | set the default IM (e.g. off) so normal-mode keymaps work |
| `InsertLeavePre` | restore | save the current IM per buffer |
| `InsertEnter` | restore | restore the buffer's saved IM |

`InsertEnter`/`CmdlineEnter` in the recommended config are load triggers only (not handlers).

### Intentionally not handled

- **`CmdlineEnter` restore** — `:` is ASCII by nature, and the per-buffer save state (`vim.b`) is shared with insert mode, so restoring on cmdline entry would clobber the insert-mode state.
- **Terminal mode** — the program inside the terminal owns its own input.

## Tests

- `bash scripts/test` — 83 cases, 0 fails. No test referenced the removed events.

## Notes

This is a deliberate behavior change for eager-loading users (no more automatic IM reset at startup). The plugin loading/initialization direction was discussed and deferred earlier; this is the agreed outcome.